### PR TITLE
Storing arrays separately from slots

### DIFF
--- a/core/Arrays.cs
+++ b/core/Arrays.cs
@@ -1,7 +1,21 @@
-﻿namespace Worlds
+﻿using System.Runtime.CompilerServices;
+
+namespace Worlds
 {
     internal struct Arrays
     {
+        private Buffer buffer;
 
+        public Values this[int index]
+        {
+            readonly get => buffer[index];
+            set => buffer[index] = value;
+        }
+
+        [InlineArray(BitMask.Capacity)]
+        private struct Buffer
+        {
+            private Values element0;
+        }
     }
 }

--- a/core/Arrays.cs
+++ b/core/Arrays.cs
@@ -1,0 +1,7 @@
+﻿namespace Worlds
+{
+    internal struct Arrays
+    {
+
+    }
+}

--- a/core/Arrays.cs
+++ b/core/Arrays.cs
@@ -12,10 +12,23 @@ namespace Worlds
             set => buffer[index] = value;
         }
 
+#if NET
         [InlineArray(BitMask.Capacity)]
         private struct Buffer
         {
             private Values element0;
         }
+#else
+        private unsafe struct Buffer
+        {
+            private fixed ulong buffer[BitMask.Capacity];
+
+            public Values this[int index]
+            {
+                readonly get => new((nint)buffer[index]);
+                set => buffer[index] = (ulong)(nint)value.pointer;
+            }
+        }
+#endif
     }
 }

--- a/core/BitMask.cs
+++ b/core/BitMask.cs
@@ -8,6 +8,11 @@ namespace Worlds
     public struct BitMask : IEquatable<BitMask>
     {
         /// <summary>
+        /// An empty bitmask.
+        /// </summary>
+        public static readonly BitMask Default = new BitMask();
+
+        /// <summary>
         /// Maximum amount of bits that can be stored.
         /// </summary>
         public const int Capacity = 256;

--- a/core/Chunk.cs
+++ b/core/Chunk.cs
@@ -13,7 +13,7 @@ namespace Worlds
     [SkipLocalsInit]
     public unsafe struct Chunk : IDisposable, IEquatable<Chunk>
     {
-        private ChunkPointer* chunk;
+        internal ChunkPointer* chunk;
 
         /// <summary>
         /// Checks if this chunk is disposed.

--- a/core/Chunk.cs
+++ b/core/Chunk.cs
@@ -37,8 +37,6 @@ namespace Worlds
             }
         }
 
-        internal readonly Span<uint> EntitiesList => new(chunk->entities.Items.Pointer, chunk->count + 1);
-
         /// <summary>
         /// Amount of entities stored in this chunk.
         /// </summary>
@@ -90,7 +88,7 @@ namespace Worlds
             chunk->count = 0;
             chunk->entities = new(4);
             chunk->entities.AddDefault(); //reserved
-            chunk->components = new(4, schema.ComponentRowSize);
+            chunk->components = new(4, schema.schema->componentRowSize);
             chunk->components.AddDefault(); //reserved
             chunk->schema = schema;
             chunk->definition = definition;
@@ -109,7 +107,7 @@ namespace Worlds
         internal readonly void UpdateStrideToMatchSchema()
         {
             chunk->components.Dispose();
-            chunk->components = new(4, chunk->schema.ComponentRowSize);
+            chunk->components = new(4, chunk->schema.schema->componentRowSize);
             chunk->components.AddDefault(); //reserved
         }
 
@@ -153,11 +151,11 @@ namespace Worlds
         public readonly int ToString(Span<char> destination)
         {
             int length = 0;
-            length += Count.ToString(destination);
-            if (!Definition.IsEmpty)
+            length += chunk->count.ToString(destination);
+            if (chunk->definition != Definition.Default)
             {
                 destination[length++] = ' ';
-                length += Definition.ToString(chunk->schema, destination.Slice(length));
+                length += chunk->definition.ToString(chunk->schema, destination.Slice(length));
             }
 
             return length;
@@ -166,7 +164,7 @@ namespace Worlds
         /// <inheritdoc/>
         public readonly override int GetHashCode()
         {
-            return Definition.GetHashCode();
+            return chunk->definition.GetHashCode();
         }
 
         /// <summary>

--- a/core/Chunk.cs
+++ b/core/Chunk.cs
@@ -1,5 +1,4 @@
-﻿using Collections;
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Unmanaged;
@@ -38,8 +37,6 @@ namespace Worlds
             }
         }
 
-        internal readonly List Components => chunk->components;
-        internal readonly uint LastEntity => chunk->lastEntity;
         internal readonly Span<uint> EntitiesList => new(chunk->entities.Items.Pointer, chunk->count + 1);
 
         /// <summary>

--- a/core/ChunkKey.cs
+++ b/core/ChunkKey.cs
@@ -7,9 +7,9 @@ namespace Worlds
         public readonly Definition definition;
         public readonly Chunk chunk;
 
-        public ChunkKey(Chunk chunk)
+        public unsafe ChunkKey(Chunk chunk)
         {
-            this.definition = chunk.Definition;
+            this.definition = chunk.chunk->definition;
             this.chunk = chunk;
         }
 

--- a/core/Component Query/ComponentQuery1.cs
+++ b/core/Component Query/ComponentQuery1.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -736,7 +736,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1> query)
+            internal unsafe Enumerator(ComponentQuery<C1> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -747,7 +747,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -797,7 +797,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -833,11 +833,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
             }
 

--- a/core/Component Query/ComponentQuery1.cs
+++ b/core/Component Query/ComponentQuery1.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1> where C1 : unmanaged
+    public unsafe struct ComponentQuery<C1> where C1 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1>());
             this.world = world;
         }
 
@@ -50,13 +50,13 @@ namespace Worlds
 
             return this;
         }
-        
+
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
         public ComponentQuery<C1> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -745,7 +745,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -787,7 +787,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 if (chunkCount > 0)
                 {
@@ -797,7 +797,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent() 
+            private readonly void ThrowIfVersionIsDifferent()
             {
                 if (version != query.world.Version)
                 {

--- a/core/Component Query/ComponentQuery10.cs
+++ b/core/Component Query/ComponentQuery10.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -763,7 +763,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -774,7 +774,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -833,7 +833,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -869,11 +869,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery10.cs
+++ b/core/Component Query/ComponentQuery10.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -772,7 +772,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -814,7 +814,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery11.cs
+++ b/core/Component Query/ComponentQuery11.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged where C11 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged where C11 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -775,7 +775,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -817,7 +817,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery11.cs
+++ b/core/Component Query/ComponentQuery11.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -766,7 +766,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -777,7 +777,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -837,7 +837,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -873,11 +873,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery12.cs
+++ b/core/Component Query/ComponentQuery12.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged where C11 : unmanaged where C12 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged where C11 : unmanaged where C12 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -778,7 +778,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -820,7 +820,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery12.cs
+++ b/core/Component Query/ComponentQuery12.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -769,7 +769,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -780,7 +780,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -841,7 +841,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -877,11 +877,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery13.cs
+++ b/core/Component Query/ComponentQuery13.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -772,7 +772,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -783,7 +783,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -845,7 +845,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -881,11 +881,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery13.cs
+++ b/core/Component Query/ComponentQuery13.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged where C11 : unmanaged where C12 : unmanaged where C13 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged where C11 : unmanaged where C12 : unmanaged where C13 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -781,7 +781,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -823,7 +823,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery14.cs
+++ b/core/Component Query/ComponentQuery14.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged where C11 : unmanaged where C12 : unmanaged where C13 : unmanaged where C14 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged where C11 : unmanaged where C12 : unmanaged where C13 : unmanaged where C14 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -784,7 +784,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -826,7 +826,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery14.cs
+++ b/core/Component Query/ComponentQuery14.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -775,7 +775,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -786,7 +786,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -849,7 +849,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -885,11 +885,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery15.cs
+++ b/core/Component Query/ComponentQuery15.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -778,7 +778,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -789,7 +789,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -853,7 +853,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -889,11 +889,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery15.cs
+++ b/core/Component Query/ComponentQuery15.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged where C11 : unmanaged where C12 : unmanaged where C13 : unmanaged where C14 : unmanaged where C15 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged where C11 : unmanaged where C12 : unmanaged where C13 : unmanaged where C14 : unmanaged where C15 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -787,7 +787,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -829,7 +829,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery16.cs
+++ b/core/Component Query/ComponentQuery16.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -781,7 +781,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -792,7 +792,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -857,7 +857,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -893,11 +893,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery16.cs
+++ b/core/Component Query/ComponentQuery16.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged where C11 : unmanaged where C12 : unmanaged where C13 : unmanaged where C14 : unmanaged where C15 : unmanaged where C16 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged where C10 : unmanaged where C11 : unmanaged where C12 : unmanaged where C13 : unmanaged where C14 : unmanaged where C15 : unmanaged where C16 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15, C16> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -790,7 +790,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -832,7 +832,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery2.cs
+++ b/core/Component Query/ComponentQuery2.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2> where C1 : unmanaged where C2 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2> where C1 : unmanaged where C2 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -748,7 +748,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -790,7 +790,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 if (chunkCount > 0)

--- a/core/Component Query/ComponentQuery2.cs
+++ b/core/Component Query/ComponentQuery2.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -739,7 +739,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -750,7 +750,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -801,7 +801,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -837,11 +837,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
             }

--- a/core/Component Query/ComponentQuery3.cs
+++ b/core/Component Query/ComponentQuery3.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -742,7 +742,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -753,7 +753,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -805,7 +805,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -841,11 +841,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery3.cs
+++ b/core/Component Query/ComponentQuery3.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -751,7 +751,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -793,7 +793,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery4.cs
+++ b/core/Component Query/ComponentQuery4.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -754,7 +754,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -796,7 +796,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery4.cs
+++ b/core/Component Query/ComponentQuery4.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -745,7 +745,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -756,7 +756,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -809,7 +809,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -845,11 +845,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery5.cs
+++ b/core/Component Query/ComponentQuery5.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -748,7 +748,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4, C5> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4, C5> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -759,7 +759,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -813,7 +813,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -849,11 +849,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery5.cs
+++ b/core/Component Query/ComponentQuery5.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4, C5> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4, C5> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4, C5>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4, C5>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -757,7 +757,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -799,7 +799,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery6.cs
+++ b/core/Component Query/ComponentQuery6.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4, C5, C6> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4, C5, C6> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4, C5, C6>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4, C5, C6>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -760,7 +760,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -802,7 +802,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery6.cs
+++ b/core/Component Query/ComponentQuery6.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -751,7 +751,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -762,7 +762,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -817,7 +817,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -853,11 +853,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery7.cs
+++ b/core/Component Query/ComponentQuery7.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -754,7 +754,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -765,7 +765,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -821,7 +821,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -857,11 +857,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery7.cs
+++ b/core/Component Query/ComponentQuery7.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -763,7 +763,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -805,7 +805,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery8.cs
+++ b/core/Component Query/ComponentQuery8.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -766,7 +766,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -808,7 +808,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery8.cs
+++ b/core/Component Query/ComponentQuery8.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -757,7 +757,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -768,7 +768,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -825,7 +825,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -861,11 +861,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Component Query/ComponentQuery9.cs
+++ b/core/Component Query/ComponentQuery9.cs
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged
+    public unsafe struct ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> where C1 : unmanaged where C2 : unmanaged where C3 : unmanaged where C4 : unmanaged where C5 : unmanaged where C6 : unmanaged where C7 : unmanaged where C8 : unmanaged where C9 : unmanaged
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<C1, C2, C3, C4, C5, C6, C7, C8, C9>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -769,7 +769,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -811,7 +811,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 componentType1 = schema.GetComponentType<C1>();
                 componentType2 = schema.GetComponentType<C2>();
                 componentType3 = schema.GetComponentType<C3>();

--- a/core/Component Query/ComponentQuery9.cs
+++ b/core/Component Query/ComponentQuery9.cs
@@ -50,7 +50,7 @@ namespace Worlds
 
             return this;
         }
-
+        
         /// <summary>
         /// Makes the given array types required.
         /// </summary>
@@ -760,7 +760,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> query)
+            internal unsafe Enumerator(ComponentQuery<C1, C2, C3, C4, C5, C6, C7, C8, C9> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -771,7 +771,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -829,7 +829,7 @@ namespace Worlds
             }
 
             [Conditional("DEBUG")]
-            private readonly void ThrowIfVersionIsDifferent()
+            private readonly void ThrowIfVersionIsDifferent() 
             {
                 if (version != query.world.Version)
                 {
@@ -865,11 +865,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 componentOffset1 = chunk.GetComponentOffset(componentType1);
                 componentOffset2 = chunk.GetComponentOffset(componentType2);
                 componentOffset3 = chunk.GetComponentOffset(componentType3);

--- a/core/Definition.cs
+++ b/core/Definition.cs
@@ -8,6 +8,11 @@ namespace Worlds
     public struct Definition : IEquatable<Definition>
     {
         /// <summary>
+        /// An empty definition.
+        /// </summary>
+        public static readonly Definition Default = new Definition();
+
+        /// <summary>
         /// The mask of component types present.
         /// </summary>
         public BitMask componentTypes;
@@ -21,16 +26,6 @@ namespace Worlds
         /// The mask of tag types present.
         /// </summary>
         public BitMask tagTypes;
-
-        /// <summary>
-        /// Does this definition include disabled entities?
-        /// </summary>
-        public readonly bool IsDisabled => tagTypes.Contains(Schema.DisabledTagType);
-
-        /// <summary>
-        /// Checks if this definition is empty.
-        /// </summary>
-        public readonly bool IsEmpty => componentTypes.IsEmpty && arrayTypes.IsEmpty && tagTypes.IsEmpty;
 
         /// <summary>
         /// Creates a new definition with the exact component and array <see cref="BitMask"/> values.
@@ -90,7 +85,7 @@ namespace Worlds
                 length -= 2;
             }
 
-            if (IsDisabled)
+            if (tagTypes.Contains(Schema.DisabledTagType))
             {
                 const string Keyword = "Disabled";
                 if (length > 0)

--- a/core/Entity.cs
+++ b/core/Entity.cs
@@ -150,9 +150,9 @@ namespace Worlds
         /// <summary>
         /// Checks if this entity complies with another entity of type <typeparamref name="T"/>
         /// </summary>
-        public readonly bool Is<T>() where T : unmanaged, IEntity
+        public unsafe readonly bool Is<T>() where T : unmanaged, IEntity
         {
-            Archetype archetype = Archetype.Get<T>(world.Schema);
+            Archetype archetype = Archetype.Get<T>(world.world->schema);
             return world.Is(value, archetype);
         }
 
@@ -175,9 +175,9 @@ namespace Worlds
         /// <summary>
         /// Makes this entity become another entity of type <typeparamref name="T"/>.
         /// </summary>
-        public readonly T Become<T>() where T : unmanaged, IEntity
+        public unsafe readonly T Become<T>() where T : unmanaged, IEntity
         {
-            Archetype archetype = Archetype.Get<T>(world.Schema);
+            Archetype archetype = Archetype.Get<T>(world.world->schema);
             world.Become(value, archetype);
             return new Entity(world, value).As<T>();
         }
@@ -704,7 +704,7 @@ namespace Worlds
             }
 
             /// <inheritdoc/>
-            public DebugView(World world, uint value)
+            public unsafe DebugView(World world, uint value)
             {
                 this.world = world;
                 this.value = value;
@@ -712,7 +712,7 @@ namespace Worlds
                 if (!destroyed)
                 {
                     Entity entity = new(world, value);
-                    Schema schema = world.Schema;
+                    Schema schema = world.world->schema;
 #if DEBUG
                     World.createStackTraces.TryGetValue(entity, out creation);
 #endif

--- a/core/Entity.cs
+++ b/core/Entity.cs
@@ -742,8 +742,7 @@ namespace Worlds
                         this.references[i] = new Entity(world, references[i]);
                     }
 
-                    Chunk chunk = world.GetChunk(value);
-                    definition = chunk.Definition;
+                    definition = world.GetDefinition(value);
 
                     //collect all component, array, tag types, and their objects
                     Span<int> typesBuffer = stackalloc int[BitMask.Capacity];

--- a/core/Exceptions/ArrayIsAlreadyPresentException.cs
+++ b/core/Exceptions/ArrayIsAlreadyPresentException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Types;
 
 namespace Worlds
 {
@@ -14,7 +15,7 @@ namespace Worlds
 
         private unsafe static string GetMessage(World world, uint entity, int componentType)
         {
-            Types.Type type = world.world->schema.GetComponentLayout(componentType);
+            TypeMetadata type = world.world->schema.GetComponentLayout(componentType);
             return $"Entity `{entity}` already has array `{type}`";
         }
     }

--- a/core/Exceptions/ArrayIsAlreadyPresentException.cs
+++ b/core/Exceptions/ArrayIsAlreadyPresentException.cs
@@ -11,9 +11,10 @@ namespace Worlds
         public ArrayIsAlreadyPresentException(World world, uint entity, int componentType) : base(GetMessage(world, entity, componentType))
         {
         }
-        private static string GetMessage(World world, uint entity, int componentType)
+
+        private unsafe static string GetMessage(World world, uint entity, int componentType)
         {
-            Types.Type type = world.Schema.GetComponentLayout(componentType);
+            Types.Type type = world.world->schema.GetComponentLayout(componentType);
             return $"Entity `{entity}` already has array `{type}`";
         }
     }

--- a/core/Exceptions/ArrayIsMissingException.cs
+++ b/core/Exceptions/ArrayIsMissingException.cs
@@ -12,9 +12,9 @@ namespace Worlds
         {
         }
 
-        private static string GetMessage(World world, uint entity, int componentType)
+        private unsafe static string GetMessage(World world, uint entity, int componentType)
         {
-            Types.Type type = world.Schema.GetComponentLayout(componentType);
+            Types.Type type = world.world->schema.GetComponentLayout(componentType);
             return $"Entity `{entity}` is missing array `{type}`";
         }
     }

--- a/core/Exceptions/ArrayIsMissingException.cs
+++ b/core/Exceptions/ArrayIsMissingException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Types;
 
 namespace Worlds
 {
@@ -14,7 +15,7 @@ namespace Worlds
 
         private unsafe static string GetMessage(World world, uint entity, int componentType)
         {
-            Types.Type type = world.world->schema.GetComponentLayout(componentType);
+            TypeMetadata type = world.world->schema.GetComponentLayout(componentType);
             return $"Entity `{entity}` is missing array `{type}`";
         }
     }

--- a/core/Exceptions/ComponentIsAlreadyPresentException.cs
+++ b/core/Exceptions/ComponentIsAlreadyPresentException.cs
@@ -11,9 +11,10 @@ namespace Worlds
         public ComponentIsAlreadyPresentException(World world, uint entity, int componentType) : base(GetMessage(world, entity, componentType))
         {
         }
-        private static string GetMessage(World world, uint entity, int componentType)
+
+        private unsafe static string GetMessage(World world, uint entity, int componentType)
         {
-            Types.Type type = world.Schema.GetComponentLayout(componentType);
+            Types.Type type = world.world->schema.GetComponentLayout(componentType);
             return $"Entity `{entity}` already has component `{type}`";
         }
     }

--- a/core/Exceptions/ComponentIsAlreadyPresentException.cs
+++ b/core/Exceptions/ComponentIsAlreadyPresentException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Types;
 
 namespace Worlds
 {
@@ -14,7 +15,7 @@ namespace Worlds
 
         private unsafe static string GetMessage(World world, uint entity, int componentType)
         {
-            Types.Type type = world.world->schema.GetComponentLayout(componentType);
+            TypeMetadata type = world.world->schema.GetComponentLayout(componentType);
             return $"Entity `{entity}` already has component `{type}`";
         }
     }

--- a/core/Exceptions/ComponentIsMissingException.cs
+++ b/core/Exceptions/ComponentIsMissingException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Types;
 
 namespace Worlds
 {
@@ -14,7 +15,7 @@ namespace Worlds
 
         private unsafe static string GetMessage(World world, uint entity, int componentType)
         {
-            Types.Type type = world.world->schema.GetComponentLayout(componentType);
+            TypeMetadata type = world.world->schema.GetComponentLayout(componentType);
             return $"Entity `{entity}` is missing component `{type}`";
         }
     }

--- a/core/Exceptions/ComponentIsMissingException.cs
+++ b/core/Exceptions/ComponentIsMissingException.cs
@@ -12,9 +12,9 @@ namespace Worlds
         {
         }
 
-        private static string GetMessage(World world, uint entity, int componentType)
+        private unsafe static string GetMessage(World world, uint entity, int componentType)
         {
-            Types.Type type = world.Schema.GetComponentLayout(componentType);
+            Types.Type type = world.world->schema.GetComponentLayout(componentType);
             return $"Entity `{entity}` is missing component `{type}`";
         }
     }

--- a/core/Exceptions/TagIsAlreadyPresentException.cs
+++ b/core/Exceptions/TagIsAlreadyPresentException.cs
@@ -12,9 +12,9 @@ namespace Worlds
         {
         }
 
-        private static string GetMessage(World world, uint entity, int tagType)
+        private unsafe static string GetMessage(World world, uint entity, int tagType)
         {
-            Types.Type type = world.Schema.GetTagLayout(tagType);
+            Types.Type type = world.world->schema.GetTagLayout(tagType);
             return $"Entity `{entity}` already has tag `{type}`";
         }
     }

--- a/core/Exceptions/TagIsAlreadyPresentException.cs
+++ b/core/Exceptions/TagIsAlreadyPresentException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Types;
 
 namespace Worlds
 {
@@ -14,7 +15,7 @@ namespace Worlds
 
         private unsafe static string GetMessage(World world, uint entity, int tagType)
         {
-            Types.Type type = world.world->schema.GetTagLayout(tagType);
+            TypeMetadata type = world.world->schema.GetTagLayout(tagType);
             return $"Entity `{entity}` already has tag `{type}`";
         }
     }

--- a/core/Exceptions/TagIsMissingException.cs
+++ b/core/Exceptions/TagIsMissingException.cs
@@ -11,9 +11,10 @@ namespace Worlds
         public TagIsMissingException(World world, uint entity, int tagType) : base(GetMessage(world, entity, tagType))
         {
         }
-        private static string GetMessage(World world, uint entity, int tagType)
+
+        private unsafe static string GetMessage(World world, uint entity, int tagType)
         {
-            Types.Type type = world.Schema.GetTagLayout(tagType);
+            Types.Type type = world.world->schema.GetTagLayout(tagType);
             return $"Entity `{entity}` is missing tag `{type}`";
         }
     }

--- a/core/Exceptions/TagIsMissingException.cs
+++ b/core/Exceptions/TagIsMissingException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Types;
 
 namespace Worlds
 {
@@ -14,7 +15,7 @@ namespace Worlds
 
         private unsafe static string GetMessage(World world, uint entity, int tagType)
         {
-            Types.Type type = world.world->schema.GetTagLayout(tagType);
+            TypeMetadata type = world.world->schema.GetTagLayout(tagType);
             return $"Entity `{entity}` is missing tag `{type}`";
         }
     }

--- a/core/Extensions/CreateExtensions.cs
+++ b/core/Extensions/CreateExtensions.cs
@@ -4,14 +4,14 @@
     /// Extension methods for <see cref="World"/> to create entities with components
     /// already present.
     /// </summary>
-    public static class CreateExtensions
+    public unsafe static class CreateExtensions
     {
         /// <summary>
         /// Creates an entity with 1 component already present.
         /// </summary>
         public static uint CreateEntity<T1>(this World world, T1 component1) where T1 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             BitMask componentTypesMask = default;
             componentTypesMask.Set(componentType1);
@@ -25,7 +25,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2>(this World world, T1 component1, T2 component2) where T1 : unmanaged where T2 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             BitMask componentTypesMask = default;
@@ -42,7 +42,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3>(this World world, T1 component1, T2 component2, T3 component3) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -62,7 +62,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4>(this World world, T1 component1, T2 component2, T3 component3, T4 component4) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -85,7 +85,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4, T5>(this World world, T1 component1, T2 component2, T3 component3, T4 component4, T5 component5) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -111,7 +111,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4, T5, T6>(this World world, T1 component1, T2 component2, T3 component3, T4 component4, T5 component5, T6 component6) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -140,7 +140,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4, T5, T6, T7>(this World world, T1 component1, T2 component2, T3 component3, T4 component4, T5 component5, T6 component6, T7 component7) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -172,7 +172,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4, T5, T6, T7, T8>(this World world, T1 component1, T2 component2, T3 component3, T4 component4, T5 component5, T6 component6, T7 component7, T8 component8) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -207,7 +207,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this World world, T1 component1, T2 component2, T3 component3, T4 component4, T5 component5, T6 component6, T7 component7, T8 component8, T9 component9) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -245,7 +245,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this World world, T1 component1, T2 component2, T3 component3, T4 component4, T5 component5, T6 component6, T7 component7, T8 component8, T9 component9, T10 component10) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -286,7 +286,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this World world, T1 component1, T2 component2, T3 component3, T4 component4, T5 component5, T6 component6, T7 component7, T8 component8, T9 component9, T10 component10, T11 component11) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -330,7 +330,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this World world, T1 component1, T2 component2, T3 component3, T4 component4, T5 component5, T6 component6, T7 component7, T8 component8, T9 component9, T10 component10, T11 component11, T12 component12) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -377,7 +377,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this World world, T1 component1, T2 component2, T3 component3, T4 component4, T5 component5, T6 component6, T7 component7, T8 component8, T9 component9, T10 component10, T11 component11, T12 component12, T13 component13) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged where T13 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -427,7 +427,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this World world, T1 component1, T2 component2, T3 component3, T4 component4, T5 component5, T6 component6, T7 component7, T8 component8, T9 component9, T10 component10, T11 component11, T12 component12, T13 component13, T14 component14) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged where T13 : unmanaged where T14 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -480,7 +480,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this World world, T1 component1, T2 component2, T3 component3, T4 component4, T5 component5, T6 component6, T7 component7, T8 component8, T9 component9, T10 component10, T11 component11, T12 component12, T13 component13, T14 component14, T15 component15) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged where T13 : unmanaged where T14 : unmanaged where T15 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();
@@ -536,7 +536,7 @@
         /// </summary>
         public static uint CreateEntity<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this World world, T1 component1, T2 component2, T3 component3, T4 component4, T5 component5, T6 component6, T7 component7, T8 component8, T9 component9, T10 component10, T11 component11, T12 component12, T13 component13, T14 component14, T15 component15, T16 component16) where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged where T13 : unmanaged where T14 : unmanaged where T15 : unmanaged where T16 : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType1 = schema.GetComponentType<T1>();
             int componentType2 = schema.GetComponentType<T2>();
             int componentType3 = schema.GetComponentType<T3>();

--- a/core/Extensions/FetchExtensions.cs
+++ b/core/Extensions/FetchExtensions.cs
@@ -6,19 +6,19 @@ namespace Worlds
     /// <summary>
     /// Fetch extensions for <see cref="World"/>s.
     /// </summary>
-    public static class FetchExtensions
+    public unsafe static class FetchExtensions
     {
         /// <summary>
         /// Tries to retrieve a reference to the first found component of type <typeparamref name="T"/>.
         /// </summary>
-        public unsafe static ref T TryGetFirstComponent<T>(this World world, out bool contains) where T : unmanaged
+        public static ref T TryGetFirstComponent<T>(this World world, out bool contains) where T : unmanaged
         {
-            int componentType = world.Schema.GetComponentType<T>();
+            int componentType = world.world->schema.GetComponentType<T>();
             ReadOnlySpan<Chunk> chunks = world.Chunks;
             for (int i = 0; i < chunks.Length; i++)
             {
                 Chunk chunk = chunks[i];
-                if (chunk.Count > 0 && chunk.Definition.ContainsComponent(componentType))
+                if (chunk.chunk->count > 0 && chunk.chunk->definition.ContainsComponent(componentType))
                 {
                     contains = true;
                     return ref chunk.GetComponent<T>(1, componentType);
@@ -34,12 +34,12 @@ namespace Worlds
         /// </summary>
         public static bool TryGetFirstComponent<T>(this World world, out T component) where T : unmanaged
         {
-            int componentType = world.Schema.GetComponentType<T>();
+            int componentType = world.world->schema.GetComponentType<T>();
             ReadOnlySpan<Chunk> chunks = world.Chunks;
             for (int i = 0; i < chunks.Length; i++)
             {
                 Chunk chunk = chunks[i];
-                if (chunk.Count > 0 && chunk.Definition.ContainsComponent(componentType))
+                if (chunk.chunk->count > 0 && chunk.chunk->definition.ContainsComponent(componentType))
                 {
                     component = chunk.GetComponent<T>(1, componentType);
                     return true;
@@ -55,12 +55,12 @@ namespace Worlds
         /// </summary>
         public static bool TryGetFirstComponent<T>(this World world, out uint entity) where T : unmanaged
         {
-            int componentType = world.Schema.GetComponentType<T>();
+            int componentType = world.world->schema.GetComponentType<T>();
             ReadOnlySpan<Chunk> chunks = world.Chunks;
             for (int i = 0; i < chunks.Length; i++)
             {
                 Chunk chunk = chunks[i];
-                if (chunk.Count > 0 && chunk.Definition.ContainsComponent(componentType))
+                if (chunk.chunk->count > 0 && chunk.chunk->definition.ContainsComponent(componentType))
                 {
                     entity = chunk.Entities[0];
                     return true;
@@ -76,12 +76,12 @@ namespace Worlds
         /// </summary>
         public unsafe static ref T TryGetFirstComponent<T>(this World world, out uint entity, out bool contains) where T : unmanaged
         {
-            int componentType = world.Schema.GetComponentType<T>();
+            int componentType = world.world->schema.GetComponentType<T>();
             ReadOnlySpan<Chunk> chunks = world.Chunks;
             for (int i = 0; i < chunks.Length; i++)
             {
                 Chunk chunk = chunks[i];
-                if (chunk.Count > 0 && chunk.Definition.ContainsComponent(componentType))
+                if (chunk.chunk->count > 0 && chunk.chunk->definition.ContainsComponent(componentType))
                 {
                     entity = chunk.Entities[0];
                     contains = true;
@@ -103,12 +103,12 @@ namespace Worlds
         /// <exception cref="NullReferenceException"></exception>"
         public static ref T GetFirstComponent<T>(this World world) where T : unmanaged
         {
-            int componentType = world.Schema.GetComponentType<T>();
+            int componentType = world.world->schema.GetComponentType<T>();
             ReadOnlySpan<Chunk> chunks = world.Chunks;
             for (int i = 0; i < chunks.Length; i++)
             {
                 Chunk chunk = chunks[i];
-                if (chunk.Count > 0 && chunk.Definition.ContainsComponent(componentType))
+                if (chunk.chunk->count > 0 && chunk.chunk->definition.ContainsComponent(componentType))
                 {
                     return ref chunk.GetComponent<T>(1, componentType);
                 }
@@ -126,12 +126,12 @@ namespace Worlds
         /// <exception cref="NullReferenceException"></exception>
         public static ref T GetFirstComponent<T>(this World world, out uint entity) where T : unmanaged
         {
-            int componentType = world.Schema.GetComponentType<T>();
+            int componentType = world.world->schema.GetComponentType<T>();
             ReadOnlySpan<Chunk> chunks = world.Chunks;
             for (int i = 0; i < chunks.Length; i++)
             {
                 Chunk chunk = chunks[i];
-                if (chunk.Count > 0 && chunk.Definition.ContainsComponent(componentType))
+                if (chunk.chunk->count > 0 && chunk.chunk->definition.ContainsComponent(componentType))
                 {
                     entity = chunk.Entities[0];
                     return ref chunk.GetComponent<T>(1, componentType);
@@ -247,19 +247,19 @@ namespace Worlds
         {
             EntityExtensions.ThrowIfNotEntity<T>();
 
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             Definition definition = Definition.Get<T>(schema);
             ReadOnlySpan<Chunk> chunks = world.Chunks;
             for (int i = 0; i < chunks.Length; i++)
             {
                 Chunk chunk = chunks[i];
-                if (!onlyEnabled || (onlyEnabled && !chunk.Definition.tagTypes.Contains(Schema.DisabledTagType)))
+                if (!onlyEnabled || (onlyEnabled && !chunk.chunk->definition.tagTypes.Contains(Schema.DisabledTagType)))
                 {
-                    if (chunk.Definition.componentTypes.ContainsAll(definition.componentTypes) && chunk.Definition.arrayTypes.ContainsAll(definition.arrayTypes))
+                    if (chunk.chunk->definition.componentTypes.ContainsAll(definition.componentTypes) && chunk.chunk->definition.arrayTypes.ContainsAll(definition.arrayTypes))
                     {
-                        if (chunk.Definition.tagTypes.ContainsAll(definition.tagTypes))
+                        if (chunk.chunk->definition.tagTypes.ContainsAll(definition.tagTypes))
                         {
-                            if (chunk.Count > 0)
+                            if (chunk.chunk->count > 0)
                             {
                                 entity = new Entity(world, chunk.Entities[0]).As<T>();
                                 return true;
@@ -289,18 +289,18 @@ namespace Worlds
         /// </summary>
         public static int CountEntitiesWith<T>(this World world, bool onlyEnabled = true) where T : unmanaged
         {
-            Schema schema = world.Schema;
+            Schema schema = world.world->schema;
             int componentType = schema.GetComponentType<T>();
             ReadOnlySpan<Chunk> chunks = world.Chunks;
             int count = 0;
             for (int i = 0; i < chunks.Length; i++)
             {
                 Chunk chunk = chunks[i];
-                if (chunk.Definition.ContainsComponent(componentType))
+                if (chunk.chunk->definition.ContainsComponent(componentType))
                 {
-                    if (!onlyEnabled || (onlyEnabled && !chunk.Definition.tagTypes.Contains(Schema.DisabledTagType)))
+                    if (!onlyEnabled || (onlyEnabled && !chunk.chunk->definition.tagTypes.Contains(Schema.DisabledTagType)))
                     {
-                        count += chunk.Count;
+                        count += chunk.chunk->count;
                     }
                 }
             }
@@ -318,11 +318,11 @@ namespace Worlds
             for (int i = 0; i < chunks.Length; i++)
             {
                 Chunk chunk = chunks[i];
-                if (chunk.Definition.ContainsComponent(componentType))
+                if (chunk.chunk->definition.ContainsComponent(componentType))
                 {
-                    if (!onlyEnabled || (onlyEnabled && !chunk.Definition.tagTypes.Contains(Schema.DisabledTagType)))
+                    if (!onlyEnabled || (onlyEnabled && !chunk.chunk->definition.tagTypes.Contains(Schema.DisabledTagType)))
                     {
-                        count += chunk.Count;
+                        count += chunk.chunk->count;
                     }
                 }
             }
@@ -337,20 +337,20 @@ namespace Worlds
         {
             EntityExtensions.ThrowIfNotEntity<T>();
 
-            Definition definition = Definition.Get<T>(world.Schema);
+            Definition definition = Definition.Get<T>(world.world->schema);
             ReadOnlySpan<Chunk> chunks = world.Chunks;
             int count = 0;
             for (int i = 0; i < chunks.Length; i++)
             {
                 Chunk chunk = chunks[i];
-                Definition chunkDefinition = chunk.Definition;
+                Definition chunkDefinition = chunk.chunk->definition;
                 if (!onlyEnabled || (onlyEnabled && !chunkDefinition.tagTypes.Contains(Schema.DisabledTagType)))
                 {
                     if (chunkDefinition.componentTypes.ContainsAll(definition.componentTypes) && chunkDefinition.arrayTypes.ContainsAll(definition.arrayTypes))
                     {
                         if (chunkDefinition.tagTypes.ContainsAll(definition.tagTypes))
                         {
-                            count += chunk.Count;
+                            count += chunk.chunk->count;
                         }
                     }
                 }

--- a/core/Functions/ProcessSchema.cs
+++ b/core/Functions/ProcessSchema.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Types;
 
 namespace Worlds.Functions
 {
@@ -9,18 +10,18 @@ namespace Worlds.Functions
     public unsafe readonly struct ProcessSchema : IEquatable<ProcessSchema>
     {
 #if NET
-        private readonly delegate* unmanaged<Input, Types.Type> function;
+        private readonly delegate* unmanaged<Input, TypeMetadata> function;
 
         /// <inheritdoc/>
-        public ProcessSchema(delegate* unmanaged<Input, Types.Type> function)
+        public ProcessSchema(delegate* unmanaged<Input, TypeMetadata> function)
         {
             this.function = function;
         }
 #else
-        private readonly delegate*<Input, Types.Type> function;
+        private readonly delegate*<Input, TypeMetadata> function;
         
         /// <inheritdoc/>
-        public ProcessSchema(delegate*<Input, Types.Type> function)
+        public ProcessSchema(delegate*<Input, TypeMetadata> function)
         {
             this.function = function;
         }
@@ -45,14 +46,13 @@ namespace Worlds.Functions
         }
 
         /// <inheritdoc/>
-        public readonly void Invoke(ref Types.Type type, DataType.Kind dataType)
+        public readonly void Invoke(ref TypeMetadata type, DataType.Kind dataType)
         {
-            Types.Type newType = function(new Input(type, dataType));
-            type = newType;
+            type = function(new Input(type, dataType));
         }
 
         /// <inheritdoc/>
-        public readonly Types.Type Invoke(Types.Type type, DataType.Kind dataType)
+        public readonly TypeMetadata Invoke(TypeMetadata type, DataType.Kind dataType)
         {
             return function(new Input(type, dataType));
         }
@@ -77,7 +77,7 @@ namespace Worlds.Functions
             /// <summary>
             /// The type being deserialized.
             /// </summary>
-            public readonly Types.Type type;
+            public readonly TypeMetadata type;
 
             /// <summary>
             /// The kind of data type that <see cref="type"/> is describing.
@@ -85,7 +85,7 @@ namespace Worlds.Functions
             public readonly DataType.Kind dataType;
 
             /// <inheritdoc/>
-            public Input(Types.Type type, DataType.Kind dataType)
+            public Input(TypeMetadata type, DataType.Kind dataType)
             {
                 this.type = type;
                 this.dataType = dataType;

--- a/core/Operation.cs
+++ b/core/Operation.cs
@@ -75,18 +75,18 @@ namespace Worlds
             operation->count++;
         }
 
-        private readonly void WriteTypeLayout(Types.Type type)
+        private readonly void WriteTypeLayout(TypeMetadata type)
         {
             MemoryAddress.ThrowIfDefault(operation);
 
-            int newLength = operation->bytesLength + sizeof(long);
+            int newLength = operation->bytesLength + sizeof(TypeMetadata);
             if (operation->bytesCapacity < newLength)
             {
                 operation->bytesCapacity = newLength.GetNextPowerOf2();
                 MemoryAddress.Resize(ref operation->buffer, operation->bytesCapacity);
             }
 
-            operation->buffer.Write(operation->bytesLength, type.Hash);
+            operation->buffer.Write(operation->bytesLength, type);
             operation->bytesLength = newLength;
         }
 
@@ -146,13 +146,13 @@ namespace Worlds
             return type;
         }
 
-        private readonly Types.Type ReadTypeLayout(ref int bytePosition)
+        private readonly TypeMetadata ReadTypeLayout(ref int bytePosition)
         {
             MemoryAddress.ThrowIfDefault(operation);
 
-            long hash = operation->buffer.Read<long>(bytePosition);
-            bytePosition += sizeof(long);
-            return MetadataRegistry.GetType(hash);
+            TypeMetadata type = operation->buffer.Read<TypeMetadata>(bytePosition);
+            bytePosition += sizeof(TypeMetadata);
+            return type;
         }
 
         private readonly T Read<T>(ref int bytePosition) where T : unmanaged
@@ -659,7 +659,7 @@ namespace Worlds
 
             private void AddComponent()
             {
-                Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
+                TypeMetadata layout = operation.ReadTypeLayout(ref bytePosition);
                 DataType dataType = world.world->schema.GetComponentDataType(layout);
                 int componentType = dataType.index;
                 ReadOnlySpan<byte> component = operation.ReadBytes(dataType.size, ref bytePosition);
@@ -672,7 +672,7 @@ namespace Worlds
 
             private void SetComponent()
             {
-                Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
+                TypeMetadata layout = operation.ReadTypeLayout(ref bytePosition);
                 DataType dataType = world.world->schema.GetComponentDataType(layout);
                 int componentType = dataType.index;
                 ReadOnlySpan<byte> component = operation.ReadBytes(dataType.size, ref bytePosition);
@@ -685,7 +685,7 @@ namespace Worlds
 
             private void AddOrSetComponent()
             {
-                Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
+                TypeMetadata layout = operation.ReadTypeLayout(ref bytePosition);
                 DataType dataType = world.world->schema.GetComponentDataType(layout);
                 int componentType = dataType.index;
                 ReadOnlySpan<byte> component = operation.ReadBytes(dataType.size, ref bytePosition);
@@ -706,7 +706,7 @@ namespace Worlds
 
             private void RemoveComponent()
             {
-                Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
+                TypeMetadata layout = operation.ReadTypeLayout(ref bytePosition);
                 DataType dataType = world.world->schema.GetComponentDataType(layout);
                 int componentType = dataType.index;
                 ReadOnlySpan<uint> selection = this.selection.AsSpan();
@@ -728,7 +728,7 @@ namespace Worlds
 
             private void CreateArray()
             {
-                Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
+                TypeMetadata layout = operation.ReadTypeLayout(ref bytePosition);
                 DataType dataType = world.world->schema.GetArrayDataType(layout);
                 int arrayType = dataType.index;
                 int arrayLength = operation.Read<int>(ref bytePosition);
@@ -741,7 +741,7 @@ namespace Worlds
 
             private void CreateAndInitializeArray()
             {
-                Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
+                TypeMetadata layout = operation.ReadTypeLayout(ref bytePosition);
                 DataType dataType = world.world->schema.GetArrayDataType(layout);
                 int arrayType = dataType.index;
                 ReadOnlySpan<uint> selection = this.selection.AsSpan();
@@ -766,7 +766,7 @@ namespace Worlds
 
             private void ResizeArray()
             {
-                Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
+                TypeMetadata layout = operation.ReadTypeLayout(ref bytePosition);
                 DataType dataType = world.world->schema.GetArrayDataType(layout);
                 int arrayType = dataType.index;
                 int length = operation.Read<int>(ref bytePosition);
@@ -781,7 +781,7 @@ namespace Worlds
             private void SetArrayElements()
             {
                 int index = operation.Read<int>(ref bytePosition);
-                Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
+                TypeMetadata layout = operation.ReadTypeLayout(ref bytePosition);
                 int length = operation.Read<int>(ref bytePosition);
                 DataType dataType = world.world->schema.GetArrayDataType(layout);
                 int arrayType = dataType.index;
@@ -798,7 +798,7 @@ namespace Worlds
 
             private void SetArray()
             {
-                Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
+                TypeMetadata layout = operation.ReadTypeLayout(ref bytePosition);
                 DataType dataType = world.world->schema.GetArrayDataType(layout);
                 int arrayType = dataType.index;
                 int length = operation.Read<int>(ref bytePosition);
@@ -814,7 +814,7 @@ namespace Worlds
 
             private void CreateOrSetArray()
             {
-                Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
+                TypeMetadata layout = operation.ReadTypeLayout(ref bytePosition);
                 DataType dataType = world.world->schema.GetArrayDataType(layout);
                 int arrayType = dataType.index;
                 int length = operation.Read<int>(ref bytePosition);

--- a/core/Operation.cs
+++ b/core/Operation.cs
@@ -660,7 +660,7 @@ namespace Worlds
             private void AddComponent()
             {
                 Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
-                DataType dataType = world.Schema.GetComponentDataType(layout);
+                DataType dataType = world.world->schema.GetComponentDataType(layout);
                 int componentType = dataType.index;
                 ReadOnlySpan<byte> component = operation.ReadBytes(dataType.size, ref bytePosition);
                 ReadOnlySpan<uint> selection = this.selection.AsSpan();
@@ -673,7 +673,7 @@ namespace Worlds
             private void SetComponent()
             {
                 Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
-                DataType dataType = world.Schema.GetComponentDataType(layout);
+                DataType dataType = world.world->schema.GetComponentDataType(layout);
                 int componentType = dataType.index;
                 ReadOnlySpan<byte> component = operation.ReadBytes(dataType.size, ref bytePosition);
                 ReadOnlySpan<uint> selection = this.selection.AsSpan();
@@ -686,7 +686,7 @@ namespace Worlds
             private void AddOrSetComponent()
             {
                 Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
-                DataType dataType = world.Schema.GetComponentDataType(layout);
+                DataType dataType = world.world->schema.GetComponentDataType(layout);
                 int componentType = dataType.index;
                 ReadOnlySpan<byte> component = operation.ReadBytes(dataType.size, ref bytePosition);
                 ReadOnlySpan<uint> selection = this.selection.AsSpan();
@@ -707,7 +707,7 @@ namespace Worlds
             private void RemoveComponent()
             {
                 Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
-                DataType dataType = world.Schema.GetComponentDataType(layout);
+                DataType dataType = world.world->schema.GetComponentDataType(layout);
                 int componentType = dataType.index;
                 ReadOnlySpan<uint> selection = this.selection.AsSpan();
                 for (int i = 0; i < selection.Length; i++)
@@ -729,7 +729,7 @@ namespace Worlds
             private void CreateArray()
             {
                 Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
-                DataType dataType = world.Schema.GetArrayDataType(layout);
+                DataType dataType = world.world->schema.GetArrayDataType(layout);
                 int arrayType = dataType.index;
                 int arrayLength = operation.Read<int>(ref bytePosition);
                 ReadOnlySpan<uint> selection = this.selection.AsSpan();
@@ -742,7 +742,7 @@ namespace Worlds
             private void CreateAndInitializeArray()
             {
                 Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
-                DataType dataType = world.Schema.GetArrayDataType(layout);
+                DataType dataType = world.world->schema.GetArrayDataType(layout);
                 int arrayType = dataType.index;
                 ReadOnlySpan<uint> selection = this.selection.AsSpan();
                 int length = operation.Read<int>(ref bytePosition);
@@ -767,7 +767,7 @@ namespace Worlds
             private void ResizeArray()
             {
                 Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
-                DataType dataType = world.Schema.GetArrayDataType(layout);
+                DataType dataType = world.world->schema.GetArrayDataType(layout);
                 int arrayType = dataType.index;
                 int length = operation.Read<int>(ref bytePosition);
                 ReadOnlySpan<uint> selection = this.selection.AsSpan();
@@ -783,7 +783,7 @@ namespace Worlds
                 int index = operation.Read<int>(ref bytePosition);
                 Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
                 int length = operation.Read<int>(ref bytePosition);
-                DataType dataType = world.Schema.GetArrayDataType(layout);
+                DataType dataType = world.world->schema.GetArrayDataType(layout);
                 int arrayType = dataType.index;
                 int stride = dataType.size;
                 ReadOnlySpan<byte> bytes = operation.ReadBytes(stride * length, ref bytePosition);
@@ -799,7 +799,7 @@ namespace Worlds
             private void SetArray()
             {
                 Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
-                DataType dataType = world.Schema.GetArrayDataType(layout);
+                DataType dataType = world.world->schema.GetArrayDataType(layout);
                 int arrayType = dataType.index;
                 int length = operation.Read<int>(ref bytePosition);
                 ReadOnlySpan<byte> bytes = operation.ReadBytes(dataType.size * length, ref bytePosition);
@@ -815,7 +815,7 @@ namespace Worlds
             private void CreateOrSetArray()
             {
                 Types.Type layout = operation.ReadTypeLayout(ref bytePosition);
-                DataType dataType = world.Schema.GetArrayDataType(layout);
+                DataType dataType = world.world->schema.GetArrayDataType(layout);
                 int arrayType = dataType.index;
                 int length = operation.Read<int>(ref bytePosition);
                 ReadOnlySpan<byte> bytes = operation.ReadBytes(dataType.size * length, ref bytePosition);

--- a/core/Pointers/WorldPointer.cs
+++ b/core/Pointers/WorldPointer.cs
@@ -8,6 +8,7 @@ namespace Worlds.Pointers
         public int version;
         public Schema schema;
         public List<Slot> slots;
+        public List<Arrays> arrays;
         public Stack<uint> freeEntities;
         public ChunkMap chunks;
         public List<(EntityCreatedOrDestroyed, ulong)> entityCreatedOrDestroyed;

--- a/core/Query.cs
+++ b/core/Query.cs
@@ -6,7 +6,7 @@ namespace Worlds
     /// <summary>
     /// A native query of entities.
     /// </summary>
-    public ref struct Query
+    public unsafe ref struct Query
     {
         private readonly World world;
         private Definition required;
@@ -22,9 +22,9 @@ namespace Worlds
                 int count = 0;
                 foreach (Chunk chunk in world.Chunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if ((key.componentTypes & required.componentTypes) != required.componentTypes)
@@ -58,7 +58,7 @@ namespace Worlds
                             continue;
                         }
 
-                        count += chunk.Count;
+                        count += chunk.chunk->count;
                     }
                 }
 
@@ -78,7 +78,7 @@ namespace Worlds
         /// <summary>
         /// Creates a new query.
         /// </summary>
-        public unsafe Query(World world, Definition required = default, Definition exclude = default)
+        public Query(World world, Definition required = default, Definition exclude = default)
         {
             MemoryAddress.ThrowIfDefault((void*)world.Address);
 
@@ -109,7 +109,7 @@ namespace Worlds
         /// </summary>
         public Query RequireComponent<T>() where T : unmanaged
         {
-            required.AddComponentType<T>(world.Schema);
+            required.AddComponentType<T>(world.world->schema);
             return this;
         }
 
@@ -127,7 +127,7 @@ namespace Worlds
         /// </summary>
         public Query ExcludeComponent<T>() where T : unmanaged
         {
-            exclude.AddComponentType<T>(world.Schema);
+            exclude.AddComponentType<T>(world.world->schema);
             return this;
         }
 
@@ -136,7 +136,7 @@ namespace Worlds
         /// </summary>
         public Query RequireArrayElement<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -154,7 +154,7 @@ namespace Worlds
         /// </summary>
         public Query ExcludeArray<T>() where T : unmanaged
         {
-            exclude.AddArrayType<T>(world.Schema);
+            exclude.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -163,7 +163,7 @@ namespace Worlds
         /// </summary>
         public Query RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -181,7 +181,7 @@ namespace Worlds
         /// </summary>
         public Query ExcludeTag<T>() where T : unmanaged
         {
-            exclude.AddTagType<T>(world.Schema);
+            exclude.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -200,9 +200,9 @@ namespace Worlds
         {
             foreach (Chunk chunk in world.Chunks)
             {
-                if (chunk.Count > 0)
+                if (chunk.chunk->count > 0)
                 {
-                    Definition key = chunk.Definition;
+                    Definition key = chunk.chunk->definition;
 
                     //check if chunk contains inclusion
                     if ((key.componentTypes & required.componentTypes) != required.componentTypes)
@@ -273,7 +273,7 @@ namespace Worlds
                 for (int i = 0; i < world.Chunks.Length; i++)
                 {
                     Chunk chunk = world.Chunks[i];
-                    Definition key = chunk.Definition;
+                    Definition key = chunk.chunk->definition;
 
                     //check if chunk contains inclusion
                     if ((key.componentTypes & required.componentTypes) != required.componentTypes)
@@ -318,7 +318,7 @@ namespace Worlds
             /// </summary>
             public bool MoveNext()
             {
-                if (entityIndex < chunk.Count)
+                if (entityIndex < chunk.chunk->count)
                 {
                     entityIndex++;
                     return true;
@@ -332,9 +332,9 @@ namespace Worlds
                     for (int i = chunkIndex + 1; i < world.Chunks.Length; i++)
                     {
                         Chunk chunk = world.Chunks[i];
-                        if (chunk.Count > 0)
+                        if (chunk.chunk->count > 0)
                         {
-                            Definition key = chunk.Definition;
+                            Definition key = chunk.chunk->definition;
 
                             //check if chunk contains inclusion
                             if ((key.componentTypes & required.componentTypes) != required.componentTypes)

--- a/core/Schema.cs
+++ b/core/Schema.cs
@@ -543,6 +543,17 @@ namespace Worlds
         }
 
         /// <summary>
+        /// Tries to retrieve the index of the component type with the given <paramref name="fullTypeName"/>.
+        /// </summary>
+        public readonly bool TryGetComponentType(ReadOnlySpan<char> fullTypeName, out int componentType)
+        {
+            MemoryAddress.ThrowIfDefault(schema);
+
+            Span<long> componentTypeHashes = new(schema->typeHashes.Pointer, BitMask.Capacity);
+            return componentTypeHashes.TryIndexOf(fullTypeName.GetLongHashCode(), out componentType);
+        }
+
+        /// <summary>
         /// Checks if an array with <paramref name="fullTypeName"/> has been registered.
         /// </summary>
         public readonly bool ContainsArrayType(ASCIIText256 fullTypeName)
@@ -569,8 +580,21 @@ namespace Worlds
         /// </summary>
         public readonly bool TryGetArrayType(Types.Type type, out int arrayType)
         {
+            MemoryAddress.ThrowIfDefault(schema);
+
             Span<long> arrayTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity, BitMask.Capacity);
             return arrayTypeHashes.TryIndexOf(type.Hash, out arrayType);
+        }
+
+        /// <summary>
+        /// Tries to retrieve the index of the array type with the given <paramref name="fullTypeName"/>.
+        /// </summary>
+        public readonly bool TryGetArrayType(ReadOnlySpan<char> fullTypeName, out int arrayType)
+        {
+            MemoryAddress.ThrowIfDefault(schema);
+
+            Span<long> arrayTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity, BitMask.Capacity);
+            return arrayTypeHashes.TryIndexOf(fullTypeName.GetLongHashCode(), out arrayType);
         }
 
         /// <summary>
@@ -578,6 +602,8 @@ namespace Worlds
         /// </summary>
         public readonly bool ContainsTagType(ASCIIText256 fullTypeName)
         {
+            MemoryAddress.ThrowIfDefault(schema);
+
             Span<long> tagTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity * 2, BitMask.Capacity);
             return tagTypeHashes.Contains(fullTypeName.GetLongHashCode());
         }
@@ -587,6 +613,8 @@ namespace Worlds
         /// </summary>
         public readonly bool ContainsTagType(Types.Type type)
         {
+            MemoryAddress.ThrowIfDefault(schema);
+
             Span<long> tagTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity * 2, BitMask.Capacity);
             return tagTypeHashes.Contains(type.Hash);
         }
@@ -596,6 +624,8 @@ namespace Worlds
         /// </summary>
         public readonly bool TryGetTagType(Types.Type type, out int tagType)
         {
+            MemoryAddress.ThrowIfDefault(schema);
+
             Span<long> tagTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity * 2, BitMask.Capacity);
             return tagTypeHashes.TryIndexOf(type.Hash, out tagType);
         }
@@ -612,7 +642,7 @@ namespace Worlds
             }
 
             Span<long> componentTypeHashes = new(schema->typeHashes.Pointer, BitMask.Capacity);
-            return componentTypeHashes.Contains(TypeLayoutHashCodeCache<T>.value);
+            return componentTypeHashes.Contains(TypeHashes<T>.value);
         }
 
         /// <summary>
@@ -658,7 +688,7 @@ namespace Worlds
             }
 
             Span<long> arrayTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity, BitMask.Capacity);
-            return arrayTypeHashes.Contains(TypeLayoutHashCodeCache<T>.value);
+            return arrayTypeHashes.Contains(TypeHashes<T>.value);
         }
 
         /// <summary>
@@ -725,7 +755,7 @@ namespace Worlds
             }
 
             Span<long> tagTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity * 2, BitMask.Capacity);
-            return tagTypeHashes.Contains(TypeLayoutHashCodeCache<T>.value);
+            return tagTypeHashes.Contains(TypeHashes<T>.value);
         }
 
         /// <summary>
@@ -1576,7 +1606,7 @@ namespace Worlds
             return !(left == right);
         }
 
-        private static class TypeLayoutHashCodeCache<T> where T : unmanaged
+        private static class TypeHashes<T> where T : unmanaged
         {
             public static readonly long value = MetadataRegistry.GetType<T>().Hash;
         }
@@ -1650,7 +1680,7 @@ namespace Worlds
                     Array.Resize(ref components, componentCapacity);
 
                     Span<long> componentTypeHashes = new(schema.schema->typeHashes.Pointer, BitMask.Capacity);
-                    int componentType = componentTypeHashes.IndexOf(TypeLayoutHashCodeCache<T>.value);
+                    int componentType = componentTypeHashes.IndexOf(TypeHashes<T>.value);
                     components[schemaIndex] = componentType;
                     return componentType;
                 }
@@ -1669,7 +1699,7 @@ namespace Worlds
                     Array.Resize(ref arrays, arrayCapacity);
 
                     Span<long> arrayTypeHashes = new(schema.schema->typeHashes.Pointer + BitMask.Capacity * sizeof(long), BitMask.Capacity);
-                    int arrayType = arrayTypeHashes.IndexOf(TypeLayoutHashCodeCache<T>.value);
+                    int arrayType = arrayTypeHashes.IndexOf(TypeHashes<T>.value);
                     arrays[schemaIndex] = arrayType;
                     return arrayType;
                 }
@@ -1688,7 +1718,7 @@ namespace Worlds
                     Array.Resize(ref tags, tagCapacity);
 
                     Span<long> tagTypeHashes = new(schema.schema->typeHashes.Pointer + BitMask.Capacity * sizeof(long) * 2, BitMask.Capacity);
-                    int tagType = tagTypeHashes.IndexOf(TypeLayoutHashCodeCache<T>.value);
+                    int tagType = tagTypeHashes.IndexOf(TypeHashes<T>.value);
                     tags[schemaIndex] = tagType;
                     return tagType;
                 }

--- a/core/Schema.cs
+++ b/core/Schema.cs
@@ -23,7 +23,7 @@ namespace Worlds
 
         private static int createdSchemas;
 
-        private SchemaPointer* schema;
+        internal SchemaPointer* schema;
 
         /// <summary>
         /// Checks if this schema is disposed.

--- a/core/Schema.cs
+++ b/core/Schema.cs
@@ -147,11 +147,11 @@ namespace Worlds
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        private readonly Types.Type[] Components
+        private readonly TypeMetadata[] Components
         {
             get
             {
-                Types.Type[] buffer = new Types.Type[schema->componentCount];
+                TypeMetadata[] buffer = new TypeMetadata[schema->componentCount];
                 uint count = 0;
                 for (int c = 0; c < BitMask.Capacity; c++)
                 {
@@ -166,11 +166,11 @@ namespace Worlds
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        private readonly Types.Type[] Arrays
+        private readonly TypeMetadata[] Arrays
         {
             get
             {
-                Types.Type[] buffer = new Types.Type[schema->arraysCount];
+                TypeMetadata[] buffer = new TypeMetadata[schema->arraysCount];
                 uint count = 0;
                 for (int a = 0; a < BitMask.Capacity; a++)
                 {
@@ -185,11 +185,11 @@ namespace Worlds
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        private readonly Types.Type[] Tags
+        private readonly TypeMetadata[] Tags
         {
             get
             {
-                Types.Type[] buffer = new Types.Type[schema->tagsCount];
+                TypeMetadata[] buffer = new TypeMetadata[schema->tagsCount];
                 uint count = 0;
                 for (int t = 0; t < BitMask.Capacity; t++)
                 {
@@ -335,46 +335,44 @@ namespace Worlds
         /// <summary>
         /// Retrieves the type layout for the given <paramref name="componentType"/>.
         /// </summary>
-        public readonly Types.Type GetComponentLayout(int componentType)
+        public readonly TypeMetadata GetComponentLayout(int componentType)
         {
             MemoryAddress.ThrowIfDefault(schema);
             ThrowIfComponentTypeIsMissing(componentType);
 
             Span<long> componentTypeHashes = new(schema->typeHashes.Pointer, BitMask.Capacity);
             long hash = componentTypeHashes[componentType];
-            return MetadataRegistry.GetType(hash);
+            return new(hash);
         }
 
         /// <summary>
         /// Retrieves the type layout for the given <paramref name="arrayType"/>.
         /// </summary>
-        public readonly Types.Type GetArrayLayout(int arrayType)
+        public readonly TypeMetadata GetArrayLayout(int arrayType)
         {
             MemoryAddress.ThrowIfDefault(schema);
             ThrowIfArrayTypeIsMissing(arrayType);
 
-            Span<long> arrayTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity, BitMask.Capacity);
-            long hash = arrayTypeHashes[arrayType];
-            return MetadataRegistry.GetType(hash);
+            Span<TypeMetadata> arrayTypeHashes = schema->typeHashes.AsSpan<TypeMetadata>(BitMask.Capacity, BitMask.Capacity);
+            return arrayTypeHashes[arrayType];
         }
 
         /// <summary>
         /// Retrieves the type layout for the given <paramref name="tagType"/>.
         /// </summary>
-        public readonly Types.Type GetTagLayout(int tagType)
+        public readonly TypeMetadata GetTagLayout(int tagType)
         {
             MemoryAddress.ThrowIfDefault(schema);
             ThrowIfTagIsMissing(tagType);
 
-            Span<long> tagTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity * 2, BitMask.Capacity);
-            long hash = tagTypeHashes[tagType];
-            return MetadataRegistry.GetType(hash);
+            Span<TypeMetadata> tagTypeHashes = schema->typeHashes.AsSpan<TypeMetadata>(BitMask.Capacity * 2, BitMask.Capacity);
+            return tagTypeHashes[tagType];
         }
 
         /// <summary>
         /// Retrieves the type metadata for the component of type <typeparamref name="T"/>.
         /// </summary>
-        public readonly Types.Type GetComponentLayout<T>() where T : unmanaged
+        public readonly TypeMetadata GetComponentLayout<T>() where T : unmanaged
         {
             return GetComponentLayout(GetComponentType<T>());
         }
@@ -394,7 +392,7 @@ namespace Worlds
         /// Registers <paramref name="type"/> as a component and
         /// retrieves its index in the schema.
         /// </summary>
-        public readonly int RegisterComponent(Types.Type type)
+        public readonly int RegisterComponent(TypeMetadata type)
         {
             if (TryGetComponentType(type, out int componentType))
             {
@@ -405,10 +403,10 @@ namespace Worlds
 
             componentType = schema->componentCount;
             schema->componentOffsets.WriteElement(componentType, schema->componentRowSize);
-            schema->sizes.WriteElement(componentType, (int)type.size);
-            schema->typeHashes.WriteElement(componentType, type.Hash);
+            schema->sizes.WriteElement(componentType, (int)type.Size);
+            schema->typeHashes.WriteElement(componentType, type);
             schema->componentCount++;
-            schema->componentRowSize += type.size;
+            schema->componentRowSize += type.Size;
             schema->definitionMask.AddComponentType(componentType);
             return componentType;
         }
@@ -428,7 +426,7 @@ namespace Worlds
         /// Registers <paramref name="type"/> as an array and
         /// retrieves its index in the schema.
         /// </summary>
-        public readonly int RegisterArray(Types.Type type)
+        public readonly int RegisterArray(TypeMetadata type)
         {
             if (TryGetArrayType(type, out int arrayType))
             {
@@ -439,9 +437,9 @@ namespace Worlds
 
             arrayType = schema->arraysCount;
             Span<int> arraySizes = schema->sizes.AsSpan<int>(BitMask.Capacity, BitMask.Capacity);
-            Span<long> arrayHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity, BitMask.Capacity);
-            arraySizes[schema->arraysCount] = type.size;
-            arrayHashes[schema->arraysCount] = type.Hash;
+            Span<TypeMetadata> arrayHashes = schema->typeHashes.AsSpan<TypeMetadata>(BitMask.Capacity, BitMask.Capacity);
+            arraySizes[schema->arraysCount] = type.Size;
+            arrayHashes[schema->arraysCount] = type;
             schema->arraysCount++;
             schema->definitionMask.AddArrayType(arrayType);
             return arrayType;
@@ -462,7 +460,7 @@ namespace Worlds
         /// Registers <paramref name="type"/> as a tag and
         /// retrieves its index in the schema.
         /// </summary>
-        public readonly int RegisterTag(Types.Type type)
+        public readonly int RegisterTag(TypeMetadata type)
         {
             if (TryGetTagType(type, out int tagType))
             {
@@ -472,8 +470,8 @@ namespace Worlds
             ThrowIfTooManyTags();
 
             tagType = schema->tagsCount;
-            Span<long> tagHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity * 2, BitMask.Capacity);
-            tagHashes[tagType] = type.Hash;
+            Span<TypeMetadata> tagHashes = schema->typeHashes.AsSpan<TypeMetadata>(BitMask.Capacity * 2, BitMask.Capacity);
+            tagHashes[tagType] = type;
             schema->definitionMask.AddTagType(tagType);
             schema->tagsCount++;
             return tagType;
@@ -523,23 +521,23 @@ namespace Worlds
         /// <summary>
         /// Checks if <paramref name="type"/> is a registered component.
         /// </summary>
-        public readonly bool ContainsComponentType(Types.Type type)
+        public readonly bool ContainsComponentType(TypeMetadata type)
         {
             MemoryAddress.ThrowIfDefault(schema);
 
-            Span<long> componentTypeHashes = new(schema->typeHashes.Pointer, BitMask.Capacity);
-            return componentTypeHashes.Contains(type.Hash);
+            Span<TypeMetadata> componentTypeHashes = new(schema->typeHashes.Pointer, BitMask.Capacity);
+            return componentTypeHashes.Contains(type);
         }
 
         /// <summary>
         /// Tries to retrieve the index of the component type <paramref name="type"/>.
         /// </summary>
-        public readonly bool TryGetComponentType(Types.Type type, out int componentType)
+        public readonly bool TryGetComponentType(TypeMetadata type, out int componentType)
         {
             MemoryAddress.ThrowIfDefault(schema);
 
-            Span<long> componentTypeHashes = new(schema->typeHashes.Pointer, BitMask.Capacity);
-            return componentTypeHashes.TryIndexOf(type.Hash, out componentType);
+            Span<TypeMetadata> componentTypeHashes = new(schema->typeHashes.Pointer, BitMask.Capacity);
+            return componentTypeHashes.TryIndexOf(type, out componentType);
         }
 
         /// <summary>
@@ -567,23 +565,23 @@ namespace Worlds
         /// <summary>
         /// Checks if <paramref name="type"/> is a registered array.
         /// </summary>
-        public readonly bool ContainsArrayType(Types.Type type)
+        public readonly bool ContainsArrayType(TypeMetadata type)
         {
             MemoryAddress.ThrowIfDefault(schema);
 
-            Span<long> arrayTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity, BitMask.Capacity);
-            return arrayTypeHashes.Contains(type.Hash);
+            Span<TypeMetadata> arrayTypeHashes = schema->typeHashes.AsSpan<TypeMetadata>(BitMask.Capacity, BitMask.Capacity);
+            return arrayTypeHashes.Contains(type);
         }
 
         /// <summary>
         /// Tries to retrieve the index of the array type <paramref name="type"/>.
         /// </summary>
-        public readonly bool TryGetArrayType(Types.Type type, out int arrayType)
+        public readonly bool TryGetArrayType(TypeMetadata type, out int arrayType)
         {
             MemoryAddress.ThrowIfDefault(schema);
 
-            Span<long> arrayTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity, BitMask.Capacity);
-            return arrayTypeHashes.TryIndexOf(type.Hash, out arrayType);
+            Span<TypeMetadata> arrayTypeHashes = schema->typeHashes.AsSpan<TypeMetadata>(BitMask.Capacity, BitMask.Capacity);
+            return arrayTypeHashes.TryIndexOf(type, out arrayType);
         }
 
         /// <summary>
@@ -611,23 +609,23 @@ namespace Worlds
         /// <summary>
         /// Checks if <paramref name="type"/> is a registered tag.
         /// </summary>
-        public readonly bool ContainsTagType(Types.Type type)
+        public readonly bool ContainsTagType(TypeMetadata type)
         {
             MemoryAddress.ThrowIfDefault(schema);
 
-            Span<long> tagTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity * 2, BitMask.Capacity);
-            return tagTypeHashes.Contains(type.Hash);
+            Span<TypeMetadata> tagTypeHashes = schema->typeHashes.AsSpan<TypeMetadata>(BitMask.Capacity * 2, BitMask.Capacity);
+            return tagTypeHashes.Contains(type);
         }
 
         /// <summary>
         /// Tries to retrieve the index of the tag type <paramref name="type"/>.
         /// </summary>
-        public readonly bool TryGetTagType(Types.Type type, out int tagType)
+        public readonly bool TryGetTagType(TypeMetadata type, out int tagType)
         {
             MemoryAddress.ThrowIfDefault(schema);
 
-            Span<long> tagTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity * 2, BitMask.Capacity);
-            return tagTypeHashes.TryIndexOf(type.Hash, out tagType);
+            Span<TypeMetadata> tagTypeHashes = schema->typeHashes.AsSpan<TypeMetadata>(BitMask.Capacity * 2, BitMask.Capacity);
+            return tagTypeHashes.TryIndexOf(type, out tagType);
         }
 
         /// <summary>
@@ -641,8 +639,8 @@ namespace Worlds
                 return false;
             }
 
-            Span<long> componentTypeHashes = new(schema->typeHashes.Pointer, BitMask.Capacity);
-            return componentTypeHashes.Contains(TypeHashes<T>.value);
+            Span<TypeMetadata> componentTypeHashes = new(schema->typeHashes.Pointer, BitMask.Capacity);
+            return componentTypeHashes.Contains(TypeMetadata.Get<T>());
         }
 
         /// <summary>
@@ -668,13 +666,13 @@ namespace Worlds
         /// <summary>
         /// Retrieves the type information for component of <paramref name="type"/>.
         /// </summary>
-        public readonly DataType GetComponentDataType(Types.Type type)
+        public readonly DataType GetComponentDataType(TypeMetadata type)
         {
             ThrowIfComponentTypeIsMissing(type);
 
             Span<long> componentTypeHashes = new(schema->typeHashes.Pointer, BitMask.Capacity);
-            int componentType = componentTypeHashes.IndexOf(type.Hash);
-            return new(componentType, DataType.Kind.Component, type.size);
+            int componentType = componentTypeHashes.IndexOf(type.hash);
+            return new(componentType, DataType.Kind.Component, type.Size);
         }
 
         /// <summary>
@@ -687,8 +685,8 @@ namespace Worlds
                 return false;
             }
 
-            Span<long> arrayTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity, BitMask.Capacity);
-            return arrayTypeHashes.Contains(TypeHashes<T>.value);
+            Span<TypeMetadata> arrayTypeHashes = schema->typeHashes.AsSpan<TypeMetadata>(BitMask.Capacity, BitMask.Capacity);
+            return arrayTypeHashes.Contains(TypeMetadata.Get<T>());
         }
 
         /// <summary>
@@ -714,13 +712,13 @@ namespace Worlds
         /// <summary>
         /// Retrieves the type information for array of <paramref name="type"/>.
         /// </summary>
-        public readonly DataType GetArrayDataType(Types.Type type)
+        public readonly DataType GetArrayDataType(TypeMetadata type)
         {
             ThrowIfArrayTypeIsMissing(type);
 
             Span<long> arrayTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity, BitMask.Capacity);
-            int arrayType = arrayTypeHashes.IndexOf(type.Hash);
-            return new(arrayType, DataType.Kind.Array, type.size);
+            int arrayType = arrayTypeHashes.IndexOf(type.hash);
+            return new(arrayType, DataType.Kind.Array, type.Size);
         }
 
         /// <summary>
@@ -754,8 +752,8 @@ namespace Worlds
                 return false;
             }
 
-            Span<long> tagTypeHashes = schema->typeHashes.AsSpan<long>(BitMask.Capacity * 2, BitMask.Capacity);
-            return tagTypeHashes.Contains(TypeHashes<T>.value);
+            Span<TypeMetadata> tagTypeHashes = schema->typeHashes.AsSpan<TypeMetadata>(BitMask.Capacity * 2, BitMask.Capacity);
+            return tagTypeHashes.Contains(TypeMetadata.Get<T>());
         }
 
         /// <summary>
@@ -1466,7 +1464,7 @@ namespace Worlds
         }
 
         [Conditional("DEBUG")]
-        private readonly void ThrowIfComponentTypeIsMissing(Types.Type componentType)
+        private readonly void ThrowIfComponentTypeIsMissing(TypeMetadata componentType)
         {
             if (!ContainsComponentType(componentType))
             {
@@ -1493,7 +1491,7 @@ namespace Worlds
         }
 
         [Conditional("DEBUG")]
-        private readonly void ThrowIfArrayTypeIsMissing(Types.Type arrayType)
+        private readonly void ThrowIfArrayTypeIsMissing(TypeMetadata arrayType)
         {
             if (!ContainsArrayType(arrayType))
             {
@@ -1606,11 +1604,6 @@ namespace Worlds
             return !(left == right);
         }
 
-        private static class TypeHashes<T> where T : unmanaged
-        {
-            public static readonly long value = MetadataRegistry.GetType<T>().Hash;
-        }
-
         /// <summary>
         /// Cache of types per <see cref="Schema"/>.
         /// </summary>
@@ -1679,8 +1672,8 @@ namespace Worlds
                     componentCapacity = schemaIndex + 1;
                     Array.Resize(ref components, componentCapacity);
 
-                    Span<long> componentTypeHashes = new(schema.schema->typeHashes.Pointer, BitMask.Capacity);
-                    int componentType = componentTypeHashes.IndexOf(TypeHashes<T>.value);
+                    Span<TypeMetadata> componentTypes = new(schema.schema->typeHashes.Pointer, BitMask.Capacity);
+                    int componentType = componentTypes.IndexOf(TypeMetadata.Get<T>());
                     components[schemaIndex] = componentType;
                     return componentType;
                 }
@@ -1698,8 +1691,8 @@ namespace Worlds
                     arrayCapacity = schemaIndex + 1;
                     Array.Resize(ref arrays, arrayCapacity);
 
-                    Span<long> arrayTypeHashes = new(schema.schema->typeHashes.Pointer + BitMask.Capacity * sizeof(long), BitMask.Capacity);
-                    int arrayType = arrayTypeHashes.IndexOf(TypeHashes<T>.value);
+                    Span<TypeMetadata> arrayTypes = new(schema.schema->typeHashes.Pointer + BitMask.Capacity * sizeof(long), BitMask.Capacity);
+                    int arrayType = arrayTypes.IndexOf(TypeMetadata.Get<T>());
                     arrays[schemaIndex] = arrayType;
                     return arrayType;
                 }
@@ -1717,8 +1710,8 @@ namespace Worlds
                     tagCapacity = schemaIndex + 1;
                     Array.Resize(ref tags, tagCapacity);
 
-                    Span<long> tagTypeHashes = new(schema.schema->typeHashes.Pointer + BitMask.Capacity * sizeof(long) * 2, BitMask.Capacity);
-                    int tagType = tagTypeHashes.IndexOf(TypeHashes<T>.value);
+                    Span<TypeMetadata> tagTypes = new(schema.schema->typeHashes.Pointer + BitMask.Capacity * sizeof(long) * 2, BitMask.Capacity);
+                    int tagType = tagTypes.IndexOf(TypeMetadata.Get<T>());
                     tags[schemaIndex] = tagType;
                     return tagType;
                 }

--- a/core/Slot.cs
+++ b/core/Slot.cs
@@ -1,5 +1,4 @@
-﻿using Collections.Generic;
-using System;
+﻿using System;
 
 namespace Worlds
 {
@@ -29,7 +28,7 @@ namespace Worlds
         public Chunk chunk;
 
         /// <summary>
-        /// The index of the entity in this slot within the <see cref="chunk"/>.
+        /// The index of the entity in this slot inside its own chunk.
         /// </summary>
         public int index;
 
@@ -40,16 +39,6 @@ namespace Worlds
 
         public int referenceStart;
         public int referenceCount;
-
-        /// <summary>
-        /// All arrays stored in the entity.
-        /// </summary>
-        public Array<Values> arrays;
-
-        /// <summary>
-        /// The definition of the <see cref="chunk"/>.
-        /// </summary>
-        public readonly Definition Definition => chunk.Definition;
 
         /// <summary>
         /// Checks if this slot contains arrays.
@@ -70,21 +59,6 @@ namespace Worlds
         /// Checks if this slot has outdated children.
         /// </summary>
         public readonly bool ChildrenOutdated => (flags & Flags.ChildrenOutdated) != 0;
-
-        public static Slot CreateDefault()
-        {
-            Slot slot = default;
-            slot.parent = 0;
-            slot.state = State.Free;
-            slot.flags = Flags.None;
-            slot.chunk = default;
-            slot.index = default;
-            slot.childrenCount = default;
-            slot.referenceStart = default;
-            slot.referenceCount = default;
-            slot.arrays = default;
-            return slot;
-        }
 
         /// <summary>
         /// All possible states of an entity.

--- a/core/Slot.cs
+++ b/core/Slot.cs
@@ -41,26 +41,6 @@ namespace Worlds
         public int referenceCount;
 
         /// <summary>
-        /// Checks if this slot contains arrays.
-        /// </summary>
-        public readonly bool ContainsArrays => (flags & Flags.ContainsArrays) != 0;
-
-        /// <summary>
-        /// Checks if this slot contains children.
-        /// </summary>
-        public readonly bool ContainsChildren => (flags & Flags.ContainsChildren) != 0;
-
-        /// <summary>
-        /// Checks if this slot has outdated arrays.
-        /// </summary>
-        public readonly bool ArraysOutdated => (flags & Flags.ArraysOutdated) != 0;
-
-        /// <summary>
-        /// Checks if this slot has outdated children.
-        /// </summary>
-        public readonly bool ChildrenOutdated => (flags & Flags.ChildrenOutdated) != 0;
-
-        /// <summary>
         /// All possible states of an entity.
         /// </summary>
         public enum State : byte

--- a/core/Values.cs
+++ b/core/Values.cs
@@ -397,6 +397,11 @@ namespace Worlds
             this.pointer = array;
         }
 
+        internal Values(nint address)
+        {
+            this.pointer = (ArrayPointer*)address;
+        }
+
         internal readonly void Dispose()
         {
             Array array = new(pointer);

--- a/core/Values.cs
+++ b/core/Values.cs
@@ -426,12 +426,31 @@ namespace Worlds
             }
         }
 
+        [Conditional("DEBUG")]
+        private readonly void ThrowIfSizeMismatch<T>() where T : unmanaged
+        {
+            if (sizeof(T) != pointer->stride)
+            {
+                throw new InvalidOperationException($"Size of {sizeof(T)} does not match {pointer->stride}");
+            }
+        }
+
         /// <summary>
         /// Retrieves this entire array as a span of bytes.
         /// </summary>
         public readonly Span<byte> AsSpan()
         {
             return new(pointer->items.Pointer, pointer->length * pointer->stride);
+        }
+
+        /// <summary>
+        /// Retrieves this entire array as a span of <typeparamref name="T"/>.
+        /// </summary>
+        public readonly Span<T> AsSpan<T>() where T : unmanaged
+        {
+            ThrowIfSizeMismatch<T>();
+
+            return new(pointer->items.Pointer, pointer->length);
         }
 
         /// <summary>

--- a/core/World.cs
+++ b/core/World.cs
@@ -585,8 +585,7 @@ namespace Worlds
         /// <summary>
         /// Adds a function that listens to whenever an entity is either created, or destroyed.
         /// </summary>
-        public readonly void ListenToEntityCreationOrDestruction(EntityCreatedOrDestroyed function,
-            ulong userData = default)
+        public readonly void ListenToEntityCreationOrDestruction(EntityCreatedOrDestroyed function, ulong userData = default)
         {
             MemoryAddress.ThrowIfDefault(world);
 

--- a/core/World.cs
+++ b/core/World.cs
@@ -11,6 +11,7 @@ namespace Worlds
     /// <summary>
     /// Contains arbitrary data sorted into groups of entities for processing.
     /// </summary>
+    [SkipLocalsInit]
     public unsafe struct World : IDisposable, IEquatable<World>, ISerializable
     {
 #if DEBUG
@@ -255,7 +256,7 @@ namespace Worlds
             for (int e = 1; e < slots.Length; e++)
             {
                 Slot slot = slots[e];
-                if (slot.ContainsArrays)
+                if ((slot.flags & Slot.Flags.ContainsArrays) != 0)
                 {
                     Arrays arraySlot = arrays[e];
                     for (int a = 0; a < BitMask.Capacity; a++)
@@ -773,7 +774,7 @@ namespace Worlds
             }
 
             //modify descendants
-            if (entitySlot.ContainsChildren)
+            if ((entitySlot.flags & Slot.Flags.ContainsChildren) != 0)
             {
                 //todo: this temporary allocation can be avoided by tracking how large the tree is
                 //and then using stackalloc
@@ -819,7 +820,7 @@ namespace Worlds
                     }
 
                     //check through children
-                    if (currentSlot.ContainsChildren && !currentSlot.ChildrenOutdated)
+                    if ((currentSlot.flags & Slot.Flags.ContainsChildren) != 0 && (currentSlot.flags & Slot.Flags.ChildrenOutdated) == 0)
                     {
                         PushChildrenToStack(this, stack, currentEntity);
                     }
@@ -1188,13 +1189,13 @@ namespace Worlds
                 slots[(int)oldParent].childrenCount--; //old parent can be 0, which is ok
 
                 ref Slot newParentSlot = ref slots[(int)newParent];
-                if (!newParentSlot.ContainsChildren)
+                if ((newParentSlot.flags & Slot.Flags.ContainsChildren) == 0)
                 {
                     newParentSlot.childrenCount = 0;
                     newParentSlot.flags |= Slot.Flags.ContainsChildren;
                     newParentSlot.flags &= ~Slot.Flags.ChildrenOutdated;
                 }
-                else if (newParentSlot.ChildrenOutdated)
+                else if ((newParentSlot.flags & Slot.Flags.ChildrenOutdated) != 0)
                 {
                     newParentSlot.childrenCount = 0;
                     newParentSlot.flags &= ~Slot.Flags.ChildrenOutdated;
@@ -1709,12 +1710,12 @@ namespace Worlds
             ref Slot slot = ref slots[(int)entity];
             ref Arrays arrays = ref world->arrays[entity];
 
-            if (!slot.ContainsArrays)
+            if ((slot.flags & Slot.Flags.ContainsArrays) == 0)
             {
                 slot.flags |= Slot.Flags.ContainsArrays;
                 slot.flags &= ~Slot.Flags.ArraysOutdated;
             }
-            else if (slot.ArraysOutdated)
+            else if ((slot.flags & Slot.Flags.ArraysOutdated) != 0)
             {
                 slot.flags &= ~Slot.Flags.ArraysOutdated;
                 for (int a = 0; a < BitMask.Capacity; a++)
@@ -1758,12 +1759,12 @@ namespace Worlds
             ref Slot slot = ref slots[(int)entity];
             ref Arrays arrays = ref world->arrays[entity];
 
-            if (!slot.ContainsArrays)
+            if ((slot.flags & Slot.Flags.ContainsArrays) == 0)
             {
                 slot.flags |= Slot.Flags.ContainsArrays;
                 slot.flags &= ~Slot.Flags.ArraysOutdated;
             }
-            else if (slot.ArraysOutdated)
+            else if ((slot.flags & Slot.Flags.ArraysOutdated) != 0)
             {
                 slot.flags &= ~Slot.Flags.ArraysOutdated;
                 for (int a = 0; a < BitMask.Capacity; a++)
@@ -1807,12 +1808,12 @@ namespace Worlds
             ref Slot slot = ref slots[(int)entity];
             ref Arrays arrays = ref world->arrays[entity];
 
-            if (!slot.ContainsArrays)
+            if ((slot.flags & Slot.Flags.ContainsArrays) == 0)
             {
                 slot.flags |= Slot.Flags.ContainsArrays;
                 slot.flags &= ~Slot.Flags.ArraysOutdated;
             }
-            else if (slot.ArraysOutdated)
+            else if ((slot.flags & Slot.Flags.ArraysOutdated) != 0)
             {
                 slot.flags &= ~Slot.Flags.ArraysOutdated;
                 for (int a = 0; a < BitMask.Capacity; a++)
@@ -1858,12 +1859,12 @@ namespace Worlds
             ref Slot slot = ref slots[(int)entity];
             ref Arrays arrays = ref world->arrays[entity];
 
-            if (!slot.ContainsArrays)
+            if ((slot.flags & Slot.Flags.ContainsArrays) == 0)
             {
                 slot.flags |= Slot.Flags.ContainsArrays;
                 slot.flags &= ~Slot.Flags.ArraysOutdated;
             }
-            else if (slot.ArraysOutdated)
+            else if ((slot.flags & Slot.Flags.ArraysOutdated) != 0)
             {
                 slot.flags &= ~Slot.Flags.ArraysOutdated;
                 for (int a = 0; a < BitMask.Capacity; a++)
@@ -1909,12 +1910,12 @@ namespace Worlds
             ref Slot slot = ref slots[(int)entity];
             ref Arrays arrays = ref world->arrays[entity];
 
-            if (!slot.ContainsArrays)
+            if ((slot.flags & Slot.Flags.ContainsArrays) == 0)
             {
                 slot.flags |= Slot.Flags.ContainsArrays;
                 slot.flags &= ~Slot.Flags.ArraysOutdated;
             }
-            else if (slot.ArraysOutdated)
+            else if ((slot.flags & Slot.Flags.ArraysOutdated) != 0)
             {
                 slot.flags &= ~Slot.Flags.ArraysOutdated;
                 for (int a = 0; a < BitMask.Capacity; a++)
@@ -1958,12 +1959,12 @@ namespace Worlds
             ref Slot slot = ref slots[(int)entity];
             ref Arrays arrays = ref world->arrays[entity];
 
-            if (!slot.ContainsArrays)
+            if ((slot.flags & Slot.Flags.ContainsArrays) == 0)
             {
                 slot.flags |= Slot.Flags.ContainsArrays;
                 slot.flags &= ~Slot.Flags.ArraysOutdated;
             }
-            else if (slot.ArraysOutdated)
+            else if ((slot.flags & Slot.Flags.ArraysOutdated) != 0)
             {
                 slot.flags &= ~Slot.Flags.ArraysOutdated;
                 for (int a = 0; a < BitMask.Capacity; a++)
@@ -3214,7 +3215,7 @@ namespace Worlds
                 if (parent != default)
                 {
                     ref Slot parentSlot = ref value.world->slots[(int)parent];
-                    if (!parentSlot.ContainsChildren)
+                    if ((parentSlot.flags & Slot.Flags.ContainsChildren) == 0)
                     {
                         parentSlot.flags |= Slot.Flags.ContainsChildren;
                     }

--- a/core/World.cs
+++ b/core/World.cs
@@ -657,7 +657,7 @@ namespace Worlds
             slot.state = Slot.State.Free;
             slot.referenceCount = default;
 
-            ref Slot lastSlot = ref slots[(int)slot.chunk.LastEntity];
+            ref Slot lastSlot = ref slots[(int)slot.chunk.chunk->lastEntity];
             lastSlot.index = slot.index;
 
             //remove from parents children list
@@ -763,9 +763,9 @@ namespace Worlds
                     newDefinition.AddTagType(Schema.DisabledTagType);
                 }
 
-                if (entity != entitySlot.chunk.LastEntity)
+                if (entity != entitySlot.chunk.chunk->lastEntity)
                 {
-                    slots[(int)entitySlot.chunk.LastEntity].index = entitySlot.index;
+                    slots[(int)entitySlot.chunk.chunk->lastEntity].index = entitySlot.index;
                 }
 
                 Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -809,9 +809,9 @@ namespace Worlds
                             newDefinition.AddTagType(Schema.DisabledTagType);
                         }
 
-                        if (currentEntity != currentSlot.chunk.LastEntity)
+                        if (currentEntity != currentSlot.chunk.chunk->lastEntity)
                         {
-                            slots[(int)currentSlot.chunk.LastEntity].index = currentSlot.index;
+                            slots[(int)currentSlot.chunk.chunk->lastEntity].index = currentSlot.index;
                         }
 
                         Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -1229,9 +1229,9 @@ namespace Worlds
                         newDefinition.AddTagType(Schema.DisabledTagType);
                     }
 
-                    if (entity != entitySlot.chunk.LastEntity)
+                    if (entity != entitySlot.chunk.chunk->lastEntity)
                     {
-                        slots[(int)entitySlot.chunk.LastEntity].index = entitySlot.index;
+                        slots[(int)entitySlot.chunk.chunk->lastEntity].index = entitySlot.index;
                     }
 
                     Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -1587,9 +1587,9 @@ namespace Worlds
             Definition newDefinition = slot.chunk.Definition;
             newDefinition.AddTagType(tagType);
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -1612,9 +1612,9 @@ namespace Worlds
             Definition newDefinition = slot.chunk.Definition;
             newDefinition.AddTagType(tagType);
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -1639,9 +1639,9 @@ namespace Worlds
             Definition newDefinition = slot.chunk.Definition;
             newDefinition.RemoveTagType(tagType);
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -1664,9 +1664,9 @@ namespace Worlds
             Definition newDefinition = slot.chunk.Definition;
             newDefinition.RemoveTagType(tagType);
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -1731,9 +1731,9 @@ namespace Worlds
             Definition newDefinition = slot.chunk.Definition;
             newDefinition.AddArrayType(arrayType);
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -1780,9 +1780,9 @@ namespace Worlds
             Definition newDefinition = slot.chunk.Definition;
             newDefinition.AddArrayType(arrayType);
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -1829,9 +1829,9 @@ namespace Worlds
             Definition newDefinition = slot.chunk.Definition;
             newDefinition.AddArrayType(dataType.index);
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -1880,9 +1880,9 @@ namespace Worlds
             Definition newDefinition = slot.chunk.Definition;
             newDefinition.AddArrayType(arrayType);
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -1931,9 +1931,9 @@ namespace Worlds
             Definition newDefinition = slot.chunk.Definition;
             newDefinition.AddArrayType(arrayType);
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -1980,9 +1980,9 @@ namespace Worlds
             Definition newDefinition = slot.chunk.Definition;
             newDefinition.AddArrayType(arrayType);
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -2171,9 +2171,9 @@ namespace Worlds
             Definition newDefinition = slot.chunk.Definition;
             newDefinition.RemoveArrayType(arrayType);
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -2201,9 +2201,9 @@ namespace Worlds
             Definition newDefinition = slot.chunk.Definition;
             newDefinition.RemoveArrayType(arrayType);
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Chunk destinationChunk = world->chunks.GetOrCreate(newDefinition);
@@ -2226,9 +2226,9 @@ namespace Worlds
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Definition definition = slot.chunk.Definition;
@@ -2252,9 +2252,9 @@ namespace Worlds
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Definition definition = slot.chunk.Definition;
@@ -2281,9 +2281,9 @@ namespace Worlds
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Definition definition = slot.chunk.Definition;
@@ -2310,9 +2310,9 @@ namespace Worlds
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Definition definition = slot.chunk.Definition;
@@ -2336,9 +2336,9 @@ namespace Worlds
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Definition definition = slot.chunk.Definition;
@@ -2361,9 +2361,9 @@ namespace Worlds
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Definition definition = slot.chunk.Definition;
@@ -2387,9 +2387,9 @@ namespace Worlds
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Definition definition = slot.chunk.Definition;
@@ -2414,9 +2414,9 @@ namespace Worlds
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Definition definition = slot.chunk.Definition;
@@ -2444,9 +2444,9 @@ namespace Worlds
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Definition definition = slot.chunk.Definition;
@@ -2471,9 +2471,9 @@ namespace Worlds
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Definition definition = slot.chunk.Definition;
@@ -2496,9 +2496,9 @@ namespace Worlds
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
 
-            if (entity != slot.chunk.LastEntity)
+            if (entity != slot.chunk.chunk->lastEntity)
             {
-                slots[(int)slot.chunk.LastEntity].index = slot.index;
+                slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
             Definition definition = slot.chunk.Definition;

--- a/core/World.cs
+++ b/core/World.cs
@@ -192,6 +192,7 @@ namespace Worlds
             world->schema = schema;
             world->version = 0;
             world->slots = new(4);
+            world->arrays = new(4);
             world->freeEntities = new(4);
             world->chunks = new(schema);
             world->entityCreatedOrDestroyed = new(4);
@@ -204,6 +205,7 @@ namespace Worlds
 
             //add reserve values at index 0
             world->slots.AddDefault();
+            world->arrays.AddDefault();
         }
 #endif
 
@@ -216,6 +218,7 @@ namespace Worlds
             world->schema = schema;
             world->version = 0;
             world->slots = new(4);
+            world->arrays = new(4);
             world->freeEntities = new(4);
             world->chunks = new(schema);
             world->entityCreatedOrDestroyed = new(4);
@@ -228,6 +231,7 @@ namespace Worlds
 
             //add reserve values at index 0
             world->slots.AddDefault();
+            world->arrays.AddDefault();
         }
 
         /// <summary>
@@ -273,6 +277,7 @@ namespace Worlds
             world->freeEntities.Dispose();
             world->chunks.Dispose();
             world->slots.Dispose();
+            world->arrays.Dispose();
             MemoryAddress.Free(ref world);
         }
 

--- a/core/World.cs
+++ b/core/World.cs
@@ -22,7 +22,7 @@ namespace Worlds
         /// </summary>
         public const uint DataVersion = 1;
 
-        private WorldPointer* world;
+        internal WorldPointer* world;
 
         /// <summary>
         /// Native address of the world.
@@ -495,7 +495,7 @@ namespace Worlds
                 }
 
                 Chunk chunk = slot.chunk;
-                Definition definition = chunk.Definition;
+                Definition definition = chunk.chunk->definition;
                 writer.WriteValue(e);
                 writer.WriteValue(slot.state);
                 writer.WriteValue(slot.parent);
@@ -575,7 +575,7 @@ namespace Worlds
                     continue;
                 }
 
-                uint destinationEntity = destinationWorld.CreateEntity(sourceSlot.chunk.Definition);
+                uint destinationEntity = destinationWorld.CreateEntity(sourceSlot.chunk.chunk->definition);
                 sourceWorld.CopyComponentsTo(e, destinationWorld, destinationEntity);
                 sourceWorld.CopyArraysTo(e, destinationWorld, destinationEntity);
                 sourceWorld.CopyTagsTo(e, destinationWorld, destinationEntity);
@@ -748,7 +748,7 @@ namespace Worlds
 
             //move to different chunk
             Chunk previousChunk = entitySlot.chunk;
-            Definition previousDefinition = previousChunk.Definition;
+            Definition previousDefinition = previousChunk.chunk->definition;
             bool oldEnabled = !previousDefinition.tagTypes.Contains(Schema.DisabledTagType);
             bool newEnabled = entitySlot.state == Slot.State.Enabled;
             if (oldEnabled != newEnabled)
@@ -795,7 +795,7 @@ namespace Worlds
 
                     //move descentant to proper chunk
                     previousChunk = currentSlot.chunk;
-                    previousDefinition = previousChunk.Definition;
+                    previousDefinition = previousChunk.chunk->definition;
                     oldEnabled = !previousDefinition.tagTypes.Contains(Schema.DisabledTagType);
                     if (oldEnabled != enabled)
                     {
@@ -904,7 +904,7 @@ namespace Worlds
 
             //create arrays if necessary
             BitMask arrayTypes = definition.arrayTypes;
-            if (!arrayTypes.IsEmpty)
+            if (arrayTypes != BitMask.Default)
             {
                 ref Arrays arrays = ref world->arrays[entity];
                 for (int a = 0; a < BitMask.Capacity; a++)
@@ -946,7 +946,7 @@ namespace Worlds
 
             //create arrays if necessary
             BitMask arrayTypes = definition.arrayTypes;
-            if (!arrayTypes.IsEmpty)
+            if (arrayTypes != BitMask.Default)
             {
                 ref Arrays arrays = ref world->arrays[entity];
                 for (int a = 0; a < BitMask.Capacity; a++)
@@ -1014,7 +1014,7 @@ namespace Worlds
         {
             ThrowIfEntityIsMissing(entity);
 
-            Definition currentDefinition = world->slots[entity].chunk.Definition;
+            Definition currentDefinition = world->slots[entity].chunk.chunk->definition;
             if (!currentDefinition.componentTypes.ContainsAll(definition.componentTypes))
             {
                 return false;
@@ -1214,7 +1214,7 @@ namespace Worlds
 
                 //move to different chunk if disabled state changed
                 Chunk previousChunk = entitySlot.chunk;
-                Definition previousDefinition = previousChunk.Definition;
+                Definition previousDefinition = previousChunk.chunk->definition;
                 bool oldEnabled = !previousDefinition.tagTypes.Contains(Schema.DisabledTagType);
                 bool newEnabled = entitySlot.state == Slot.State.Enabled;
                 if (oldEnabled != newEnabled)
@@ -1584,7 +1584,7 @@ namespace Worlds
 
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
-            Definition newDefinition = slot.chunk.Definition;
+            Definition newDefinition = slot.chunk.chunk->definition;
             newDefinition.AddTagType(tagType);
 
             if (entity != slot.chunk.chunk->lastEntity)
@@ -1609,7 +1609,7 @@ namespace Worlds
 
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
-            Definition newDefinition = slot.chunk.Definition;
+            Definition newDefinition = slot.chunk.chunk->definition;
             newDefinition.AddTagType(tagType);
 
             if (entity != slot.chunk.chunk->lastEntity)
@@ -1636,7 +1636,7 @@ namespace Worlds
 
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
-            Definition newDefinition = slot.chunk.Definition;
+            Definition newDefinition = slot.chunk.chunk->definition;
             newDefinition.RemoveTagType(tagType);
 
             if (entity != slot.chunk.chunk->lastEntity)
@@ -1661,7 +1661,7 @@ namespace Worlds
 
             Span<Slot> slots = world->slots.AsSpan();
             ref Slot slot = ref slots[(int)entity];
-            Definition newDefinition = slot.chunk.Definition;
+            Definition newDefinition = slot.chunk.chunk->definition;
             newDefinition.RemoveTagType(tagType);
 
             if (entity != slot.chunk.chunk->lastEntity)
@@ -1728,7 +1728,7 @@ namespace Worlds
                 }
             }
 
-            Definition newDefinition = slot.chunk.Definition;
+            Definition newDefinition = slot.chunk.chunk->definition;
             newDefinition.AddArrayType(arrayType);
 
             if (entity != slot.chunk.chunk->lastEntity)
@@ -1777,7 +1777,7 @@ namespace Worlds
                 }
             }
 
-            Definition newDefinition = slot.chunk.Definition;
+            Definition newDefinition = slot.chunk.chunk->definition;
             newDefinition.AddArrayType(arrayType);
 
             if (entity != slot.chunk.chunk->lastEntity)
@@ -1826,7 +1826,7 @@ namespace Worlds
                 }
             }
 
-            Definition newDefinition = slot.chunk.Definition;
+            Definition newDefinition = slot.chunk.chunk->definition;
             newDefinition.AddArrayType(dataType.index);
 
             if (entity != slot.chunk.chunk->lastEntity)
@@ -1877,7 +1877,7 @@ namespace Worlds
                 }
             }
 
-            Definition newDefinition = slot.chunk.Definition;
+            Definition newDefinition = slot.chunk.chunk->definition;
             newDefinition.AddArrayType(arrayType);
 
             if (entity != slot.chunk.chunk->lastEntity)
@@ -1928,7 +1928,7 @@ namespace Worlds
                 }
             }
 
-            Definition newDefinition = slot.chunk.Definition;
+            Definition newDefinition = slot.chunk.chunk->definition;
             newDefinition.AddArrayType(arrayType);
 
             if (entity != slot.chunk.chunk->lastEntity)
@@ -1977,7 +1977,7 @@ namespace Worlds
                 }
             }
 
-            Definition newDefinition = slot.chunk.Definition;
+            Definition newDefinition = slot.chunk.chunk->definition;
             newDefinition.AddArrayType(arrayType);
 
             if (entity != slot.chunk.chunk->lastEntity)
@@ -2168,7 +2168,7 @@ namespace Worlds
             array.Dispose();
             arrays[arrayType] = default;
 
-            Definition newDefinition = slot.chunk.Definition;
+            Definition newDefinition = slot.chunk.chunk->definition;
             newDefinition.RemoveArrayType(arrayType);
 
             if (entity != slot.chunk.chunk->lastEntity)
@@ -2198,7 +2198,7 @@ namespace Worlds
             array.Dispose();
             arrays[arrayType] = default;
 
-            Definition newDefinition = slot.chunk.Definition;
+            Definition newDefinition = slot.chunk.chunk->definition;
             newDefinition.RemoveArrayType(arrayType);
 
             if (entity != slot.chunk.chunk->lastEntity)
@@ -2231,7 +2231,7 @@ namespace Worlds
                 slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
-            Definition definition = slot.chunk.Definition;
+            Definition definition = slot.chunk.chunk->definition;
             definition.AddComponentType(componentType);
             Chunk destinationChunk = world->chunks.GetOrCreate(definition);
             Chunk.MoveEntityAt(entity, ref slot.index, ref slot.chunk, destinationChunk);
@@ -2257,7 +2257,7 @@ namespace Worlds
                 slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
-            Definition definition = slot.chunk.Definition;
+            Definition definition = slot.chunk.chunk->definition;
             definition.AddComponentType(componentType);
             Chunk destinationChunk = world->chunks.GetOrCreate(definition);
             Chunk.MoveEntityAt(entity, ref slot.index, ref slot.chunk, destinationChunk);
@@ -2286,7 +2286,7 @@ namespace Worlds
                 slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
-            Definition definition = slot.chunk.Definition;
+            Definition definition = slot.chunk.chunk->definition;
             definition.AddComponentType(componentType);
             Chunk destinationChunk = world->chunks.GetOrCreate(definition);
             Chunk.MoveEntityAt(entity, ref slot.index, ref slot.chunk, destinationChunk);
@@ -2315,7 +2315,7 @@ namespace Worlds
                 slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
-            Definition definition = slot.chunk.Definition;
+            Definition definition = slot.chunk.chunk->definition;
             definition.AddComponentType(componentType);
             Chunk destinationChunk = world->chunks.GetOrCreate(definition);
             Chunk.MoveEntityAt(entity, ref slot.index, ref slot.chunk, destinationChunk);
@@ -2341,7 +2341,7 @@ namespace Worlds
                 slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
-            Definition definition = slot.chunk.Definition;
+            Definition definition = slot.chunk.chunk->definition;
             definition.AddComponentType(componentType);
             Chunk destinationChunk = world->chunks.GetOrCreate(definition);
             Chunk.MoveEntityAt(entity, ref slot.index, ref slot.chunk, destinationChunk);
@@ -2366,7 +2366,7 @@ namespace Worlds
                 slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
-            Definition definition = slot.chunk.Definition;
+            Definition definition = slot.chunk.chunk->definition;
             definition.AddComponentType(componentType);
             Chunk destinationChunk = world->chunks.GetOrCreate(definition);
             Chunk.MoveEntityAt(entity, ref slot.index, ref slot.chunk, destinationChunk);
@@ -2392,7 +2392,7 @@ namespace Worlds
                 slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
-            Definition definition = slot.chunk.Definition;
+            Definition definition = slot.chunk.chunk->definition;
             definition.AddComponentType(componentType);
             Chunk destinationChunk = world->chunks.GetOrCreate(definition);
             Chunk.MoveEntityAt(entity, ref slot.index, ref slot.chunk, destinationChunk);
@@ -2419,7 +2419,7 @@ namespace Worlds
                 slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
-            Definition definition = slot.chunk.Definition;
+            Definition definition = slot.chunk.chunk->definition;
             definition.AddComponentType(componentType);
             Chunk destinationChunk = world->chunks.GetOrCreate(definition);
             Chunk.MoveEntityAt(entity, ref slot.index, ref slot.chunk, destinationChunk);
@@ -2449,7 +2449,7 @@ namespace Worlds
                 slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
-            Definition definition = slot.chunk.Definition;
+            Definition definition = slot.chunk.chunk->definition;
             definition.AddComponentType(componentType);
             Chunk destinationChunk = world->chunks.GetOrCreate(definition);
             Chunk.MoveEntityAt(entity, ref slot.index, ref slot.chunk, destinationChunk);
@@ -2476,7 +2476,7 @@ namespace Worlds
                 slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
-            Definition definition = slot.chunk.Definition;
+            Definition definition = slot.chunk.chunk->definition;
             definition.RemoveComponentType(componentType);
             Chunk destinationChunk = world->chunks.GetOrCreate(definition);
             Chunk.MoveEntityAt(entity, ref slot.index, ref slot.chunk, destinationChunk);
@@ -2501,7 +2501,7 @@ namespace Worlds
                 slots[(int)slot.chunk.chunk->lastEntity].index = slot.index;
             }
 
-            Definition definition = slot.chunk.Definition;
+            Definition definition = slot.chunk.chunk->definition;
             definition.RemoveComponentType(componentType);
             Chunk destinationChunk = world->chunks.GetOrCreate(definition);
             Chunk.MoveEntityAt(entity, ref slot.index, ref slot.chunk, destinationChunk);
@@ -2518,9 +2518,9 @@ namespace Worlds
             int componentType = world->schema.GetComponentType<T>();
             foreach (Chunk chunk in world->chunks.chunkMap->chunks)
             {
-                if (chunk.Definition.componentTypes.Contains(componentType))
+                if (chunk.chunk->definition.componentTypes.Contains(componentType))
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         return true;
                     }
@@ -2684,7 +2684,7 @@ namespace Worlds
             MemoryAddress.ThrowIfDefault(world);
 
             ref Slot slot = ref world->slots[entity];
-            contains = slot.chunk.Definition.componentTypes.Contains(componentType);
+            contains = slot.chunk.chunk->definition.componentTypes.Contains(componentType);
             if (contains)
             {
                 return ref slot.chunk.GetComponent<T>(slot.index, componentType);
@@ -2705,7 +2705,7 @@ namespace Worlds
 
             int componentType = world->schema.GetComponentType<T>();
             ref Slot slot = ref world->slots[entity];
-            contains = slot.chunk.Definition.componentTypes.Contains(componentType);
+            contains = slot.chunk.chunk->definition.componentTypes.Contains(componentType);
             if (contains)
             {
                 return ref slot.chunk.GetComponent<T>(slot.index, componentType);
@@ -2725,7 +2725,7 @@ namespace Worlds
             MemoryAddress.ThrowIfDefault(world);
 
             ref Slot slot = ref world->slots[entity];
-            if (slot.chunk.Definition.componentTypes.Contains(componentType))
+            if (slot.chunk.chunk->definition.componentTypes.Contains(componentType))
             {
                 component = slot.chunk.GetComponent<T>(slot.index, componentType);
                 return true;
@@ -2747,7 +2747,7 @@ namespace Worlds
 
             int componentType = world->schema.GetComponentType<T>();
             ref Slot slot = ref world->slots[entity];
-            if (slot.chunk.Definition.componentTypes.Contains(componentType))
+            if (slot.chunk.chunk->definition.componentTypes.Contains(componentType))
             {
                 component = slot.chunk.GetComponent<T>(slot.index, componentType);
                 return true;

--- a/tests/SerializationTests.cs
+++ b/tests/SerializationTests.cs
@@ -169,7 +169,7 @@ namespace Worlds.Tests
 
             Schema loadedSchema = loadedWorld.Schema;
 
-            static Types.Type Process(Types.Type type, DataType.Kind dataType)
+            static TypeMetadata Process(TypeMetadata type, DataType.Kind dataType)
             {
                 if (type.Is<Fruit>())
                 {

--- a/tests/WorldTests.cs
+++ b/tests/WorldTests.cs
@@ -7,7 +7,7 @@ namespace Worlds.Tests
     {
         static WorldTests()
         {
-            MetadataRegistry.Load<WorldsTestsTypeBank>();
+            MetadataRegistry.Load<WorldsTestsMetadataBank>();
         }
 
         protected World CreateWorld()

--- a/types pregenerator/ComponentQuery.cs.template
+++ b/types pregenerator/ComponentQuery.cs.template
@@ -735,7 +735,7 @@ namespace Worlds
                 }
             }
 
-            internal Enumerator(ComponentQuery<{{GenericTypeArguments}}> query)
+            internal unsafe Enumerator(ComponentQuery<{{GenericTypeArguments}}> query)
             {
                 this.query = query;
                 this.version = query.world.Version;
@@ -746,7 +746,7 @@ namespace Worlds
                 {
                     if (chunk.Count > 0)
                     {
-                        Definition key = chunk.Definition;
+                        Definition key = chunk.chunk->definition;
 
                         //check if chunk contains inclusion
                         if (!key.componentTypes.ContainsAll(query.required.componentTypes))
@@ -832,11 +832,11 @@ namespace Worlds
                 }
             }
 
-            private void UpdateChunkFields(ref Chunk chunk)
+            private unsafe void UpdateChunkFields(ref Chunk chunk)
             {
-                entities = chunk.EntitiesList;
-                entityCount = chunk.Count;
-                components = chunk.Components;
+                entities = new(chunk.chunk->entities.Items.Pointer, chunk.chunk->count + 1);
+                entityCount = chunk.chunk->count;
+                components = chunk.chunk->components;
                 {{AssignComponentOffsets}}
             }
 

--- a/types pregenerator/ComponentQuery.cs.template
+++ b/types pregenerator/ComponentQuery.cs.template
@@ -8,7 +8,7 @@ namespace Worlds
     /// <summary>
     /// Component query for the component types specified.
     /// </summary>
-    public struct {{TypeName}}<{{GenericTypeArguments}}> {{TypeConstraints}}
+    public unsafe struct {{TypeName}}<{{GenericTypeArguments}}> {{TypeConstraints}}
     {
         private Definition required;
         private Definition exclude;
@@ -30,7 +30,7 @@ namespace Worlds
         {
             required = default;
             exclude = default;
-            required.AddComponentTypes(world.Schema.GetComponentTypes<{{GenericTypeArguments}}>());
+            required.AddComponentTypes(world.world->schema.GetComponentTypes<{{GenericTypeArguments}}>());
             this.world = world;
         }
 
@@ -56,7 +56,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireArray<T>() where T : unmanaged
         {
-            required.AddArrayType<T>(world.Schema);
+            required.AddArrayType<T>(world.world->schema);
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddArrayTypes<T1, T2>(world.Schema);
+            required.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -92,7 +92,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -101,7 +101,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -110,7 +110,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -119,7 +119,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -137,7 +137,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -146,7 +146,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -155,7 +155,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireTag<T>() where T : unmanaged
         {
-            required.AddTagType<T>(world.Schema);
+            required.AddTagType<T>(world.world->schema);
             return this;
         }
 
@@ -173,7 +173,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddTagTypes<T1, T2>(world.Schema);
+            required.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -182,7 +182,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3>(world.Schema);
+            required.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -191,7 +191,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -200,7 +200,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -209,7 +209,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -218,7 +218,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -227,7 +227,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -236,7 +236,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -245,7 +245,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -254,7 +254,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -263,7 +263,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -272,7 +272,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireComponent<T1>() where T1 : unmanaged
         {
-            required.AddComponentType<T1>(world.Schema);
+            required.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -281,7 +281,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            required.AddComponentTypes<T1, T2>(world.Schema);
+            required.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -299,7 +299,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -308,7 +308,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -317,7 +317,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -326,7 +326,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -335,7 +335,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -353,7 +353,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -362,7 +362,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> RequireComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            required.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -380,7 +380,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeComponent<T1>() where T1 : unmanaged
         {
-            exclude.AddComponentType<T1>(world.Schema);
+            exclude.AddComponentType<T1>(world.world->schema);
             return this;
         }
 
@@ -389,7 +389,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeComponents<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2>(world.Schema);
+            exclude.AddComponentTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -398,7 +398,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeComponents<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -407,7 +407,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeComponents<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -416,7 +416,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeComponents<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -425,7 +425,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeComponents<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -434,7 +434,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -452,7 +452,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -461,7 +461,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -470,7 +470,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -479,7 +479,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeComponents<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddComponentTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -488,7 +488,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeTag<T1>() where T1 : unmanaged
         {
-            exclude.AddTagType<T1>(world.Schema);
+            exclude.AddTagType<T1>(world.world->schema);
             return this;
         }
 
@@ -497,7 +497,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeTags<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2>(world.Schema);
+            exclude.AddTagTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -506,7 +506,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeTags<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -515,7 +515,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeTags<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -524,7 +524,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeTags<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -533,7 +533,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeTags<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -542,7 +542,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeTags<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -551,7 +551,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -560,7 +560,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -569,7 +569,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -578,7 +578,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -587,7 +587,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeTags<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddTagTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -596,7 +596,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeArray<T1>() where T1 : unmanaged
         {
-            exclude.AddArrayType<T1>(world.Schema);
+            exclude.AddArrayType<T1>(world.world->schema);
             return this;
         }
 
@@ -605,7 +605,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeArrays<T1, T2>() where T1 : unmanaged where T2 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2>(world.Schema);
+            exclude.AddArrayTypes<T1, T2>(world.world->schema);
             return this;
         }
 
@@ -614,7 +614,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeArrays<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3>(world.world->schema);
             return this;
         }
 
@@ -623,7 +623,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeArrays<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4>(world.world->schema);
             return this;
         }
 
@@ -632,7 +632,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeArrays<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5>(world.world->schema);
             return this;
         }
 
@@ -641,7 +641,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeArrays<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6>(world.world->schema);
             return this;
         }
 
@@ -650,7 +650,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7>(world.world->schema);
             return this;
         }
 
@@ -659,7 +659,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8>(world.world->schema);
             return this;
         }
 
@@ -668,7 +668,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9>(world.world->schema);
             return this;
         }
 
@@ -677,7 +677,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(world.world->schema);
             return this;
         }
 
@@ -686,7 +686,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(world.world->schema);
             return this;
         }
 
@@ -695,7 +695,7 @@ namespace Worlds
         /// </summary>
         public ComponentQuery<{{GenericTypeArguments}}> ExcludeArrays<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged where T6 : unmanaged where T7 : unmanaged where T8 : unmanaged where T9 : unmanaged where T10 : unmanaged where T11 : unmanaged where T12 : unmanaged
         {
-            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.Schema);
+            exclude.AddArrayTypes<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(world.world->schema);
             return this;
         }
 
@@ -744,7 +744,7 @@ namespace Worlds
                 Span<Chunk> chunksBuffer = stackalloc Chunk[allChunks.Length];
                 foreach (Chunk chunk in allChunks)
                 {
-                    if (chunk.Count > 0)
+                    if (chunk.chunk->count > 0)
                     {
                         Definition key = chunk.chunk->definition;
 
@@ -786,7 +786,7 @@ namespace Worlds
 
                 entityIndex = 0;
                 chunkIndex = 0;
-                Schema schema = query.world.Schema;
+                Schema schema = query.world.world->schema;
                 {{AssignComponentTypeFields}}
                 if (chunkCount > 0)
                 {


### PR DESCRIPTION
- a slot in a world no longer contains a reference to the arrays that may/may not be present on the entity
  - instead: separate list parallel to the slots
  - less cluttered slot type, more specialized array slot type
- micro optimization in other places
  - `[SkipLocalsInit]` in world because the stack allocated spans dont depend on being cleared first
  - slots no longer have properties, so less method calls at runtime